### PR TITLE
* added --sourcepass option to copy_genes.pl

### DIFF
--- a/scripts/genebuild/copy_genes.pl
+++ b/scripts/genebuild/copy_genes.pl
@@ -101,6 +101,7 @@ use Bio::EnsEMBL::Analysis::Tools::Utilities;
 my $sourcehost   = '';
 my $sourceuser   = 'ensro';
 my $sourcedbname = '';
+my $sourcepass   = undef;
 my $sourceport   = 3306;
 
 my $outhost   = '';
@@ -134,6 +135,7 @@ GetOptions( 'inhost|sourcehost:s'                  => \$sourcehost,
             'inuser|sourceuser:s'                  => \$sourceuser,
             'indbname|sourcedbname:s'              => \$sourcedbname,
             'inport|sourceport:n'                  => \$sourceport,
+            'inpass|sourcepass:s'                  => \$sourcepass,
             'in_config_name|source_config_name:s'  => \$in_config_name,
             'out_config_name|target_config_name:s' => \$out_config_name,
             'outhost|targethost:s'                 => \$outhost,
@@ -205,6 +207,7 @@ else {
   $sourcedb =
     new Bio::EnsEMBL::DBSQL::DBAdaptor( -host   => $sourcehost,
                                         -user   => $sourceuser,
+                                        -pass   => $sourcepass,
                                         -port   => $sourceport,
                                         -dbname => $sourcedbname );
   if ($attach_dna_db) {


### PR DESCRIPTION
I've added a --sourcepass option to the copy_genes.pl script as all our mysql instances require passwords. The password is undef if the option is not used.
