### PR TITLE
Make regex for matching LTRs more generic

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Runnable/RepeatMasker.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Runnable/RepeatMasker.pm
@@ -270,9 +270,9 @@ sub parse_results{
             $repeat_class = $1;
             $repeat_name = $repeatmunge;
           }
-          elsif ($repeatmunge2 =~ /(LTR\/ERV\S+)/)
+          elsif ($repeatmunge2 =~ /(LTR\S*)/)
           {
-            $repeatmunge2 =~ /(LTR\/ERV\S+)/;
+            $repeatmunge2 =~ /(LTR\S*)/;
             $repeat_class = $1;
             $repeat_name = $repeatmunge;
           }


### PR DESCRIPTION
For a recent EG analysis the output had a few different types of LTR, as well as just 'LTR', such that the regex used for parsing the output needed to be made much more general.