### PR TITLE
Warn rather than fail on a novel repeat name format.

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Runnable/RepeatMasker.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Runnable/RepeatMasker.pm
@@ -278,10 +278,11 @@ sub parse_results{
           }
           else 
           {
-            throw("Can't parse repeatmasker output for line = $_\n".
+            warning("Can't parse repeatmasker output for line = $_\n".
                      $repeatmunge."=repeatmunge\n".
                      $repeatmunge2."=repeatmunge2\n"
                 );
+            $repeat_name = $repeatmunge;
           }
           if(!$repeat_class)
           {


### PR DESCRIPTION
In EG we (very) occasionally get a repeat name which doesn't match any of the standard formats from which the repeat class can be extracted. Rather than failing to parse the result file, it'd be useful to get a warning instead, and classify it as of an unknown class.
