### PR TITLE
Two small tweaks, required for Ensembl Genomes

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Runnable/BaseExonerate.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Runnable/BaseExonerate.pm
@@ -131,7 +131,9 @@ sub new {
     }
     $self->target_seqs($target_seqs);
   } elsif (defined $target_file) {
-    throw("The given database does not exist") if ! -e $target_file;
+    if ($target_file !~ /^[\w\-\.]+:\d+$/) {
+      throw("The given database ($target_file) does not exist") if ! -e $target_file;
+    }
     $self->target_file($target_file);
   }
 

--- a/modules/Bio/EnsEMBL/Analysis/Runnable/ExonerateAlignFeature.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Runnable/ExonerateAlignFeature.pm
@@ -166,7 +166,7 @@ sub make_feature{
   } elsif ($q_strand eq '-') {
     $q_strand = -1;
   } else {
-    throw "unrecognised target strand symbol: $q_strand\n";
+    $q_strand = $q_start <= $q_end ? 1 : -1;
   }
  
   if($t_strand eq '+'){
@@ -174,7 +174,7 @@ sub make_feature{
   } elsif ($t_strand eq '-') {
     $t_strand = -1;
   } else {
-    throw "unrecognised target strand symbol: $t_strand\n";
+    $t_strand = $t_start <= $t_end ? 1 : -1;
   }
 
   if ($t_start > $t_end) {


### PR DESCRIPTION
In order to speed up execution, EG has a pipeline that runs Exonerate in server mode, where the target is a server location rather than a file. So a change is needed in the error checking to take this into account.
Also, there's no need to fail if Exonerate doesn't give an explicit strand in the results, because it can be worked out from the start/stop directionality.