### PR TITLE
Removed a reference to Bio::EnsEMBL::Root

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Tools/Blastz.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Tools/Blastz.pm
@@ -66,8 +66,6 @@ use Bio::EnsEMBL::DnaDnaAlignFeature;
 use Bio::EnsEMBL::Utils::Argument qw(rearrange); 
 
 
-our @ISA = qw(Bio::EnsEMBL::Root);
-
 sub new {
   my ($class,@args) = @_;
   my $self = bless {}, $class;


### PR DESCRIPTION
This one is needed for our LastZ pipeline but there are more references that I haven't fixed and you may want to consider

```
scripts/buildchecks/Checker.pm:@ISA = qw( Bio::EnsEMBL::Root );
scripts/buildchecks/TranscriptCluster.pm:It inherits from Bio::EnsEMBL::Root and Bio::RangeI. A TranscriptCluster is a range in the sense that it convers
scripts/buildchecks/TranscriptCluster.pm:use Bio::EnsEMBL::Root;
scripts/buildchecks/TranscriptCluster.pm:@ISA = qw(Bio::EnsEMBL::Root Bio::RangeI);
modules/Bio/EnsEMBL/Analysis/Tools/IgTranscriptFilter.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Tools/CdnaUpdateTranscriptFilter.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Tools/CdnaUpdateTranscriptFilter.pm:@ISA = qw(Bio::EnsEMBL::Root);
modules/Bio/EnsEMBL/Analysis/Tools/Finished/BPliteWrapper.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Tools/ExonerateTranscriptFilter.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Tools/ExonerateTranscriptFilter.pm:@ISA = qw(Bio::EnsEMBL::Root);
modules/Bio/EnsEMBL/Analysis/Tools/FragmentTranscriptFilter.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Tools/FragmentTranscriptFilter.pm:@ISA = qw(Bio::EnsEMBL::Root);
modules/Bio/EnsEMBL/Analysis/Tools/CodingExonOverlapFilter.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Tools/GeneBuildUtils/CollapsedCluster.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Tools/GeneBuildUtils/TranscriptExtended.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Tools/GeneBuildUtils/ExonExtended.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Tools/ClusterFilter.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Tools/ClusterFilter.pm:@ISA = qw(Bio::EnsEMBL::Root);
modules/Bio/EnsEMBL/Analysis/Tools/GenomeOverlapFilter.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Tools/Algorithms/TranscriptCluster.pm:It inherits from Bio::EnsEMBL::Root and Bio::RangeI. A TranscriptCluster is a range in the sense that it convers
modules/Bio/EnsEMBL/Analysis/RunnableDB/Exonerate2Array.pm:# Object preamble - inherits from Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Runnable/HavanaAdder.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Runnable/HavanaAdder.pm:@ISA = qw(Bio::EnsEMBL::Root);
modules/Bio/EnsEMBL/Analysis/Runnable/Pseudogene.pm:# Object preamble - inherits from Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Runnable/Finished/HalfwiseHMM.pm:# Object preamble - inherits from Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Runnable/Finished/HalfwiseHMM.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Runnable/Finished/GenewiseHmm.pm:# Object preamble - inherits from Bio::EnsEMBL::Root
modules/Bio/EnsEMBL/Analysis/Runnable/Finished/GenewiseHmm.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Runnable/Finished/Est2Genome.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Runnable/HaplotypeMapper.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Runnable/HaplotypeMapper.pm:@ISA = qw(Bio::EnsEMBL::Root);
modules/Bio/EnsEMBL/Analysis/Runnable/ProteinAnnotation/Prodom.pm:# Object preamble - inherits from Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Runnable/ProteinAnnotation/IPRScan.pm:# Object preamble - inherits from Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Runnable/Pseudogene2x.pm:# Object preamble - inherits from Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Runnable/HaplotypeProjection.pm:use Bio::EnsEMBL::Root;
modules/Bio/EnsEMBL/Analysis/Runnable/HaplotypeProjection.pm:@ISA = qw(Bio::EnsEMBL::Root);
```