### PR TITLE
Default the timer value

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Runnable/RepeatMasker.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Runnable/RepeatMasker.pm
@@ -130,7 +130,10 @@ sub run_analysis{
   # When unconfigured, does nothing.
   local $ENV{HOME} = $self->moved_home;
   print "  with HOME=$ENV{HOME} (for the cache)\n";
-
+  
+  if (not $self->timer) {
+     $self->timer('12h');
+  }
   my $remaining_time = execute_with_timer($cmd, $self->timer);
   $self->remaining_time($remaining_time);
 


### PR DESCRIPTION
I am running the Ensembl Genomes  DNAFeatures pipeline, using `Bio::EnsEMBL::EGPipeline::PipeConfig::DNAFeatures_conf` . Something stopped setting the timer, and now this module doesn't work.

12 hours is meant to intentionally be a lot, so that stuff isn't ever broken by a poor default value. The job runs for like five minutes. The other way to achieve this would be to not execute with timer when there's no timer set.