### PR TITLE
Delete downloaded file if wget fails.

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadRNASeqFastqs.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadRNASeqFastqs.pm
@@ -88,10 +88,18 @@ sub write_output {
       $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$srr/$fastq",  '-P', $path]);
       if ($res) {
         $res >>= 8;
+	# if wget failed, delete the file so it can be downloaded again when retried
+	if (-e $path.'/'.$fastq) {
+          $self->run_system_command(['rm',"$path/$fastq"]);
+        }
         $self->throw("Could not download file $fastq error code is $res");
       }
     }
     elsif ($res) {
+      # if wget failed, delete the file so it can be downloaded again when retried
+      if (-e $path.'/'.$fastq) {
+        $self->run_system_command(['rm',"$path/$fastq"]);
+      }
       $self->throw("wget died with error code $res");
     }
   }


### PR DESCRIPTION
If wget fails there is a chance a truncated file has been downloaded. This file should be deleted before the job is retried.