### PR TITLE
changes to assembly name update script

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -8243,7 +8243,7 @@ sub pipeline_analyses {
         -max_retry_count => 0,
         -flow_into => {
                         '1->A' => ['fan_otherfeatures_db', 'fan_rnaseq_db'],
-                        'A->1' => ['update_assembly_name'],},
+                        'A->1' => ['core_assembly_name_update'],},
        },
 
 
@@ -8943,7 +8943,7 @@ sub pipeline_analyses {
        },
 
       {
-        -logic_name => 'update_assembly_name',
+        -logic_name => 'core_assembly_name_update',
         -module => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
         -parameters => { 
                          cmd => 'perl '.$self->o('assembly_name_script').

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -8515,8 +8515,31 @@ sub pipeline_analyses {
         -max_retry_count => 0,
 
         -rc_name    => '4GB',
+        -flow_into  => {
+          1 => ['otherfeatures_assembly_name_update'],
+        },
       },
 
+      {
+        -logic_name => 'otherfeatures_assembly_name_update',
+        -module => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+        -parameters => {
+                       cmd => 'perl '.$self->o('assembly_name_script').
+                                ' -user '.$self->o('user').
+                                ' -pass '.$self->o('password').
+                                ' -host '.$self->o('otherfeatures_db','-host').
+                                ' -port '.$self->o('otherfeatures_db','-port').
+                                ' -dbname '.$self->o('otherfeatures_db','-dbname').
+                                ' -driver '.$self->o('hive_driver').
+                                ' -assembly_accession '.$self->o('assembly_accession').
+                                ' -assembly_name '.$self->o('assembly_name').
+                                ' -registry_host '.$self->o('registry_host').
+                                ' -registry_port '.$self->o('registry_port').
+                                ' -registry_db '.$self->o('registry_db'),
+                       },
+
+        -rc_name => 'default',
+       },
 
       {
         -logic_name => 'fan_rnaseq_db',
@@ -8892,8 +8915,32 @@ sub pipeline_analyses {
         -max_retry_count => 0,
 
         -rc_name    => '4GB',
+        -flow_into  => {
+          1 => ['rnaseq_assembly_name_update'],
+        },
       },
 
+      {
+        -logic_name => 'rnaseq_assembly_name_update',
+        -module => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+        -parameters => {
+                       cmd => 'perl '.$self->o('assembly_name_script').
+                                ' -user '.$self->o('user').
+                                ' -pass '.$self->o('password').
+                                ' -host '.$self->o('rnaseq_db','-host').
+                                ' -port '.$self->o('rnaseq_db','-port').
+                                ' -dbname '.$self->o('rnaseq_db','-dbname').
+                                ' -driver '.$self->o('hive_driver').
+                                ' -assembly_accession '.$self->o('assembly_accession').
+                                ' -assembly_name '.$self->o('assembly_name').
+                                ' -registry_host '.$self->o('registry_host').
+                                ' -registry_port '.$self->o('registry_port').
+                                ' -registry_db '.$self->o('registry_db').
+                                ' -working_dir '.$self->o('merge_dir'),
+                       },
+
+        -rc_name => 'default',
+       },
 
       {
         -logic_name => 'update_assembly_name',

--- a/scripts/update_assembly_name.pl
+++ b/scripts/update_assembly_name.pl
@@ -80,7 +80,7 @@ my $assembly_registry = new Bio::EnsEMBL::Analysis::Hive::DBSQL::AssemblyRegistr
   -user    => 'ensro',
   -dbname  => 'gb_assembly_registry');
 
-my $dba = new Bio::EnsEMBL::DBSQL::DBAdaptor(
+ my $dba = new Bio::EnsEMBL::DBSQL::DBAdaptor(
   -dbname => $dbname,
   -host   => $host,
   -port   => $port,
@@ -91,11 +91,11 @@ my $dba = new Bio::EnsEMBL::DBSQL::DBAdaptor(
 
 my $registry_assembly_name = $assembly_registry->fetch_assembly_name_by_gca($assembly_accession);
 
-#say "registry name is $registry_assembly_name and core name is $assembly_name";
 if ($registry_assembly_name eq $assembly_name){
    say "nothing to update";
 }
 else{
+  $registry_assembly_name =~ s/ /_/g;
   my $sth = $dba->dbc->prepare("UPDATE coord_system set version =?");
   $sth->bind_param(1,$registry_assembly_name);
   if ($sth->execute){
@@ -117,8 +117,11 @@ else{
   else{
     $self->throw("Could not update meta_key assembly name in meta table");
   }
-  &rename_bam_files($working_directory,$assembly_name,$registry_assembly_name);
+  if ($dbname =~ m/rnaseq/){
+    &rename_bam_files($working_directory,$assembly_name,$registry_assembly_name);
+  }
 }
+
 
 sub rename_bam_files{
   my($dir, $prev_name, $new_name) = @_;


### PR DESCRIPTION
Modified how update assembly name runs. Now it runs separately for core and core-like dbs.
Script has been tested on affected db (accipiter_nisus_core_99_1, accipiter_nisus_rnaseq_99_1).