### PR TITLE
Changes in create annotation config script

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -97,6 +97,7 @@ sub default_options {
     'ig_tr_fasta_file'          => 'human_ig_tr.fa', # What IMGT fasta file to use. File should contain protein segments with appropriate headers
     'mt_accession'              => undef, # This should be set to undef unless you know what you are doing. If you specify an accession, then you need to add the parameters to the load_mitochondrion analysis
     'production_name_modifier'  => '', # Do not set unless working with non-reference strains, breeds etc. Must include _ in modifier, e.g. _hni for medaka strain HNI
+    'compara_registry_file'     => '',
 
     # Keys for custom loading, only set/modify if that's what you're doing
     'skip_genscan_blasts'          => '1',

--- a/scripts/genebuild/create_annotation_configs.pl
+++ b/scripts/genebuild/create_annotation_configs.pl
@@ -455,6 +455,8 @@ sub parse_assembly_report {
 sub create_config {
   my ($assembly_hash) = @_;
 
+  $assembly_hash->{'compara_registry_file'} = catfile($assembly_hash->{'output_path'},$assembly_hash->{'accession'},"Databases.pm");
+
   foreach my $key (keys(%{$assembly_hash})) {
     say "ASSEMBLY: ". $key." => ".$assembly_hash->{$key};
   }
@@ -479,7 +481,7 @@ sub create_config {
       if($line =~ /\'([^\']+)\'\s*\=\>\s*('[^\']*\')/) {
         my $conf_key = $1;
         my $conf_val = $2;
-        if($assembly_hash->{$conf_key}) {
+        if(defined $assembly_hash->{$conf_key}) {
           my $sub_val = "'".$assembly_hash->{$conf_key}."'";
           $line =~ s/$conf_val/$sub_val/;
         }
@@ -658,8 +660,6 @@ sub custom_load_data {
 
 sub init_pipeline {
     my ($assembly_hash,$hive_directory,$force_init,$fh) = @_;
-
-    my $reg_conf_path = catfile($assembly_hash->{'output_path'},$assembly_hash->{'accession'},"Databases.pm");
 
     chdir($assembly_hash->{'output_path'});
     my $cmd;


### PR DESCRIPTION
The compara registry file was NOT being added to the resources - update create_config script and added parameter in Genome_annotaiotn_config. 

Also updated if statement for assembly hash to 'defined' so 0 can be used as input (e.g. if parameter 'paired_end_only' is set to 1 by default I need to be able to enter 'paired_end_only' => 0 as input in the ini file, but the if statement would evaluate to false and not update the annotation config so I changed it to defined).