### PR TITLE
Changes to allow single-end reads for RNASeq analyses

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -487,6 +487,8 @@ sub default_options {
     # in brackets; the name the read number (1, 2) and the
     # extension.
     pairing_regex => '\S+_(\d)\.\S+',
+    # For single-end reads - only need to identify the name and extension
+    single_regex  => '([^.]+)(\.\S+)',
 
     # Do you want to make models for the each individual sample as well
     # as for the pooled samples (1/0)?

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -93,7 +93,7 @@ sub default_options {
     'mapping_db'                => '', # Tied to mapping_required being set to 1, we should have a mapping db defined in this case, leave undef for now
     'uniprot_version'           => 'uniprot_2018_07', # What UniProt data dir to use for various analyses
     'vertrna_version'           => '136', # The version of VertRNA to use, should correspond to a numbered dir in VertRNA dir
-    'paired_end_only'           => '1',
+    'paired_end_only'           => '1', # Will only use paired-end rnaseq data if 1
     'ig_tr_fasta_file'          => 'human_ig_tr.fa', # What IMGT fasta file to use. File should contain protein segments with appropriate headers
     'mt_accession'              => undef, # This should be set to undef unless you know what you are doing. If you specify an accession, then you need to add the parameters to the load_mitochondrion analysis
     'production_name_modifier'  => '', # Do not set unless working with non-reference strains, breeds etc. Must include _ in modifier, e.g. _hni for medaka strain HNI

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -93,10 +93,11 @@ sub default_options {
     'mapping_db'                => '', # Tied to mapping_required being set to 1, we should have a mapping db defined in this case, leave undef for now
     'uniprot_version'           => 'uniprot_2018_07', # What UniProt data dir to use for various analyses
     'vertrna_version'           => '136', # The version of VertRNA to use, should correspond to a numbered dir in VertRNA dir
-
+    'paired_end_only'           => '1',
     'ig_tr_fasta_file'          => 'human_ig_tr.fa', # What IMGT fasta file to use. File should contain protein segments with appropriate headers
     'mt_accession'              => undef, # This should be set to undef unless you know what you are doing. If you specify an accession, then you need to add the parameters to the load_mitochondrion analysis
     'production_name_modifier'  => '', # Do not set unless working with non-reference strains, breeds etc. Must include _ in modifier, e.g. _hni for medaka strain HNI
+    'compara_registry_file'     => '',
 
     # Keys for custom loading, only set/modify if that's what you're doing
     'skip_genscan_blasts'          => '1',
@@ -453,8 +454,7 @@ sub default_options {
     # 'rnaseq_summary_file' should always be set. If 'taxon_id' or 'study_accession' are not undef
     # they will be used to retrieve the information from ENA and to create the csv file. In this case,
     # 'file_columns' and 'summary_file_delimiter' should not be changed unless you know what you are doing
-    'study_accession'        => '',
-
+    'study_accession'     => '',
     'max_reads_per_split' => 2500000, # This sets the number of reads to split the fastq files on
     'max_total_reads'     => 200000000, # This is the total number of reads to allow from a single, unsplit file
 
@@ -487,7 +487,6 @@ sub default_options {
     # in brackets; the name the read number (1, 2) and the
     # extension.
     pairing_regex => '\S+_(\d)\.\S+',
-    paired => 1,
 
     # Do you want to make models for the each individual sample as well
     # as for the pooled samples (1/0)?
@@ -1357,6 +1356,7 @@ sub pipeline_analyses {
           study_accession => $self->o('study_accession'),
           taxon_id => $self->o('species_taxon_id'),
           inputfile => $self->o('rnaseq_summary_file'),
+	  paired_end_only => $self->o('paired_end_only'),
         },
 
         -flow_into => {
@@ -5822,7 +5822,7 @@ sub pipeline_analyses {
           max_intron_length => $self->o('maxintron'),
           min_single_exon_length => 1000,
           min_span   =>   1.5,
-          paired => $self->o('paired'),
+          paired => $self->o('paired_end_only'),
           use_ucsc_naming => $self->o('use_ucsc_naming'),
         },
         -rc_name    => '2GB',
@@ -5847,7 +5847,7 @@ sub pipeline_analyses {
           max_intron_length => $self->o('maxintron'),
           min_single_exon_length => 1000,
           min_span   =>   1.5,
-          paired => $self->o('paired'),
+          paired => $self->o('paired_end_only'),
           use_ucsc_naming => $self->o('use_ucsc_naming'),
         },
         -rc_name    => '10GB',
@@ -5872,7 +5872,7 @@ sub pipeline_analyses {
           max_intron_length => $self->o('maxintron'),
           min_single_exon_length => 1000,
           min_span   =>   1.5,
-          paired => $self->o('paired'),
+          paired => $self->o('paired_end_only'),
           use_ucsc_naming => $self->o('use_ucsc_naming'),
         },
         -rc_name    => '30GB',

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -5439,6 +5439,8 @@ sub pipeline_analyses {
           'max_total_reads'     => $self->o('max_total_reads'),
           'rnaseq_summary_file' => $self->o('rnaseq_summary_file'),
           'fastq_dir'           => $self->o('input_dir'),
+	  'pairing_regex'       => $self->o('pairing_regex'),
+	  'single_regex'        => $self->o('single_regex'),
         },
       },
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveParseCsvIntoTable.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveParseCsvIntoTable.pm
@@ -102,10 +102,15 @@ sub write_output {
 	my $split_fastq = $input_id->{filename};
 	if ($split_fastq =~ m/_split/){
 	  my @split_parts = split /_/, $split_fastq;
-	  my $suffix = $split_parts[-2];
-	  my @prefix_parts = @split_parts[ 0..$#split_parts-3 ];
-	  my $prefix = join '_', @prefix_parts;
-	  $fastq = $prefix."_".$suffix;
+	  if ($split_fastq =~ m/_0\.fastq/){ #single end filename format
+	    $fastq = $split_parts[0].".fastq.gz";
+       	  }
+	  else{ #paired_end filename format
+	    my $suffix = $split_parts[-2];
+	    my @prefix_parts = @split_parts[ 0..$#split_parts-3 ];
+	    my $prefix = join '_', @prefix_parts;
+	    $fastq = $prefix."_".$suffix;
+	  }
 	}
 	else{
 	  $fastq = $split_fastq;

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/SplitFastQFiles.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/SplitFastQFiles.pm
@@ -65,6 +65,8 @@ sub fetch_input {
   $self->param_required('rnaseq_summary_file');
   $self->param_required('fastq_dir');
   $self->param_required('iid');
+  $self->param_required('pairing_regex');
+  $self->param_required('single_regex');
 }
 
 
@@ -113,8 +115,8 @@ sub run {
   say "Preparing to split the fastq file";
   my $sample_name;
   my $remainder;
-  my $pairing_regex = '(\S+)(\_\d\.\S+)';
-  my $single_regex = '([^.]+)(\.\S+)';
+  my $pairing_regex = $self->param('pairing_regex');
+  my $single_regex = $self->param('single_regex');
   if ($fastq_file_name =~ /$pairing_regex/) {
       $sample_name = $1;
       $remainder = $2;

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/SplitFastQFiles.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/SplitFastQFiles.pm
@@ -111,13 +111,22 @@ sub run {
   }
 
   say "Preparing to split the fastq file";
+  my $sample_name;
+  my $remainder;
   my $pairing_regex = '(\S+)(\_\d\.\S+)';
-  unless($fastq_file_name =~ /$pairing_regex/) {
-    $self->throw('Failed name did not match the regex. Regex used: '.$pairing_regex.' filename: '.$fastq_file_name);
+  my $single_regex = '([^.]+)(\.\S+)';
+  if ($fastq_file_name =~ /$pairing_regex/) {
+      $sample_name = $1;
+      $remainder = $2;
+  }
+  elsif ($fastq_file_name =~ /$single_regex/) {
+    $sample_name = $1;
+    $remainder = '_0'.$2;
+  }
+  else {
+    $self->throw('Failed name did not match the regex. Regex used: PAIRED: '.$pairing_regex.' OR SINGLE: '.$single_regex.' filename: '.$fastq_file_name);
   }
 
-  my $sample_name = $1;
-  my $remainder = $2;
   my $split_file_paths = $self->split_fastq($fastq_file_name,$self->param('fastq_dir'),$max_lines_per_split,$sample_name,$remainder);
   say "Fastq file has been split";
 

--- a/scripts/genebuild/create_annotation_configs.pl
+++ b/scripts/genebuild/create_annotation_configs.pl
@@ -455,6 +455,8 @@ sub parse_assembly_report {
 sub create_config {
   my ($assembly_hash) = @_;
 
+  $assembly_hash->{'compara_registry_file'} = catfile($assembly_hash->{'output_path'},$assembly_hash->{'accession'},"Databases.pm");
+
   foreach my $key (keys(%{$assembly_hash})) {
     say "ASSEMBLY: ". $key." => ".$assembly_hash->{$key};
   }
@@ -479,7 +481,8 @@ sub create_config {
       if($line =~ /\'([^\']+)\'\s*\=\>\s*('[^\']*\')/) {
         my $conf_key = $1;
         my $conf_val = $2;
-        if($assembly_hash->{$conf_key}) {
+        if(defined $assembly_hash->{$conf_key}) {
+	  print "REPLACING ".$conf_key." with ".$assembly_hash->{$conf_key}."\n";
           my $sub_val = "'".$assembly_hash->{$conf_key}."'";
           $line =~ s/$conf_val/$sub_val/;
         }
@@ -656,8 +659,6 @@ sub custom_load_data {
 
 sub init_pipeline {
     my ($assembly_hash,$hive_directory,$force_init,$fh) = @_;
-
-    my $reg_conf_path = catfile($assembly_hash->{'output_path'},$assembly_hash->{'accession'},"Databases.pm");
 
     chdir($assembly_hash->{'output_path'});
     my $cmd;


### PR DESCRIPTION
Made changes to HiveParseCsvIntoTable.pm and SplitFastQFiles.pm to allow for single-end reads (mostly just updating regexes).
Updated Genome_annotation_conf and create_annotation_config to allow for the 'paired_end_only' option to be set to 0 in the ini file.
Tested pipeline changes for platypus (only single-end rnaseq dat available): leanne_ornithorhynchus_anatinus_pipe_100@gb4