### PR TITLE
Never retry "process_assembly_info".

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -1538,6 +1538,7 @@ sub pipeline_analyses {
           target_db     => $self->o('reference_db'),
         },
         -rc_name    => '8GB',
+	-max_retry_count => 0,
         -flow_into  => {
           1 => ['load_meta_info'],
         },


### PR DESCRIPTION
Retries will fail (throwing "only one coord system at seq level" exception) and hide previous error messages because there will likely be coord system table rows inserted from previous tries.