### PR TITLE
Fix pairing_regex in Genome_annotation_conf AND add another file path format for retrieving rnaseq data

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -486,9 +486,11 @@ sub default_options {
     # the expression "\S+_(\d)\.\S+".  Need to identify the read number
     # in brackets; the name the read number (1, 2) and the
     # extension.
-    pairing_regex => '(\S+)(\_\d\.\S+)',
-    # For single-end reads - only need to identify the name and extension
-    single_regex  => '([^.]+)(\.\S+)',
+    pairing_regex => '\S+_(\d)\.\S+',
+    
+    # Regular expressions for splitting the fastq files
+    split_paired_regex   => '(\S+)(\_\d\.\S+)',
+    split_single_regex  => '([^.]+)(\.\S+)',
 
     # Do you want to make models for the each individual sample as well
     # as for the pooled samples (1/0)?
@@ -5439,8 +5441,8 @@ sub pipeline_analyses {
           'max_total_reads'     => $self->o('max_total_reads'),
           'rnaseq_summary_file' => $self->o('rnaseq_summary_file'),
           'fastq_dir'           => $self->o('input_dir'),
-	  'pairing_regex'       => $self->o('pairing_regex'),
-	  'single_regex'        => $self->o('single_regex'),
+	  'pairing_regex'       => $self->o('split_paired_regex'),
+	  'single_regex'        => $self->o('split_single_regex'),
         },
       },
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -486,7 +486,7 @@ sub default_options {
     # the expression "\S+_(\d)\.\S+".  Need to identify the read number
     # in brackets; the name the read number (1, 2) and the
     # extension.
-    pairing_regex => '\S+_(\d)\.\S+',
+    pairing_regex => '(\S+)(\_\d\.\S+)',
     # For single-end reads - only need to identify the name and extension
     single_regex  => '([^.]+)(\.\S+)',
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadRNASeqFastqs.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadRNASeqFastqs.pm
@@ -79,20 +79,24 @@ sub write_output {
     $srr = (split /\./, $fastq)[0];
   }
   my $first = substr $srr, 0, 6;
-  my $second = '00'.(substr $srr, -1, 1);
+  my $second_a = '00'.(substr $srr, -1, 1);
+  my $second_b ='0'.(substr $srr, -2, 2);
 
-  my $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$second/$srr/$fastq",  '-P', $path]);
+  my $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$second_a/$srr/$fastq",  '-P', $path]);
   if ($res) {
     $res >>= 8;
     if ($res == 8) {
-      $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$srr/$fastq",  '-P', $path]);
-      if ($res) {
-        $res >>= 8;
-	# if wget failed, delete the file so it can be downloaded again when retried
-	if (-e $path.'/'.$fastq) {
-          $self->run_system_command(['rm',"$path/$fastq"]);
-        }
-        $self->throw("Could not download file $fastq error code is $res");
+      $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$second_b/$srr/$fastq",  '-P', $path]);
+      if ($res == 8) {
+	$res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$srr/$fastq",  '-P', $path]);
+	if ($res) {
+	  $res >>= 8;
+	  # if wget failed, delete the file so it can be downloaded again when retried
+	  if (-e $path.'/'.$fastq) {
+	    $self->run_system_command(['rm',"$path/$fastq"]);
+	  }
+	  $self->throw("Could not download file $fastq error code is $res");
+	}
       }
     }
     elsif ($res) {


### PR DESCRIPTION
Fixed pairing_regex in annotation config - needed parentheses for the code that uses it.

Added to code to deal with a third directory structure type for retrieving rnaseq data from ENA.