### PR TITLE
Hotfix/sample locations

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/sample_genes_registry_conf.pl
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/sample_genes_registry_conf.pl
@@ -22,20 +22,16 @@ use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::Taxonomy::DBSQL::TaxonomyDBAdaptor;
 
 my $curr_release = $ENV{ENSEMBL_RELEASE};
-#my $curr_release = 97;
-my $prev_release = $curr_release - 1;
 
 # ---------------------- CURRENT COMPARA DATABASE ---------------------------------
 
 my $compara_dbs = {
-#    'compara_curr'   => [ 'mysql-ens-compara-prod-1', 'ensembl_compara_'.$curr_release ],
-    'compara_curr'   => [ 'mysql-ens-mirror-1', 'ensembl_compara_'.$curr_release ],
+    'compara_curr'   => [ 'mysql-ens-sta-1', 'ensembl_compara_'.$curr_release ],
 };
 
 foreach my $alias_name ( keys %$compara_dbs ) {
   my ( $host, $db_name ) = @{ $compara_dbs->{$alias_name} };
-  my ( $user, $pass ) = ( 'ensadmin', $ENV{'ENSADMIN_PSW'} );
-  ( $user, $pass ) = ( 'ensro', '' ) if ( $alias_name  =~ /_prev/ );
+  my ( $user, $pass ) = ( 'ensro', '' );
   Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->new(
             -host => $host,
             -user => $user,

--- a/scripts/genebuild/get_sample_genes.pl
+++ b/scripts/genebuild/get_sample_genes.pl
@@ -24,9 +24,7 @@ use Getopt::Long;
 use Bio::EnsEMBL::Analysis::Tools::Utilities qw(execute_with_wait);
 
 # defaults
-#use Bio::EnsEMBL::ApiVersion;
 my $current_release = $ENV{ENSEMBL_RELEASE};
-#my $current_release = 97;
 my $max_len = 100000;
 my $min_len = $max_len * 0.75;
 
@@ -114,13 +112,13 @@ if ($reg_conf) {
 	my $sample_coord=$sample_gene->seq_region_name().':'.$sample_gene->seq_region_start().'-'.$sample_gene->seq_region_end();
 
 	print OUT "\nUSE ".$db_name.";
-UPDATE meta set meta_value='".$sample_coord."' WHERE meta_key='sample.location_param');
-UPDATE meta set meta_value='".$sample_coord."' WHERE meta_key='sample.location_text');
-UPDATE meta set meta_value='".$sample_gene->stable_id()."' WHERE meta_key='sample.gene_param');
-UPDATE meta set meta_value='".$sample_gene->external_name()."' WHERE meta_key='sample.gene_text');
-UPDATE meta set meta_value='".$sample_transcript->stable_id()."' WHERE meta_key='sample.transcript_param');
-UPDATE meta set meta_value='".$sample_transcript->external_name()."' WHERE meta_key='sample.transcript_text');
-UPDATE meta set meta_value='".$sample_gene->external_name()."' WHERE meta_key='sample.search_text');"
+UPDATE meta set meta_value='".$sample_coord."' WHERE meta_key='sample.location_param';
+UPDATE meta set meta_value='".$sample_coord."' WHERE meta_key='sample.location_text';
+UPDATE meta set meta_value='".$sample_gene->stable_id()."' WHERE meta_key='sample.gene_param';
+UPDATE meta set meta_value='".$sample_gene->external_name()."' WHERE meta_key='sample.gene_text';
+UPDATE meta set meta_value='".$sample_transcript->stable_id()."' WHERE meta_key='sample.transcript_param';
+UPDATE meta set meta_value='".$sample_transcript->external_name()."' WHERE meta_key='sample.transcript_text';
+UPDATE meta set meta_value='".$sample_gene->external_name()."' WHERE meta_key='sample.search_text';"
 }
 
 #locations will now exist in meta as placholder info so replaces sql statesments with above ^

--- a/scripts/genebuild/get_sample_genes.pl
+++ b/scripts/genebuild/get_sample_genes.pl
@@ -118,7 +118,7 @@ UPDATE meta set meta_value='".$sample_gene->stable_id()."' WHERE meta_key='sampl
 UPDATE meta set meta_value='".$sample_gene->external_name()."' WHERE meta_key='sample.gene_text';
 UPDATE meta set meta_value='".$sample_transcript->stable_id()."' WHERE meta_key='sample.transcript_param';
 UPDATE meta set meta_value='".$sample_transcript->external_name()."' WHERE meta_key='sample.transcript_text';
-UPDATE meta set meta_value='".$sample_gene->external_name()."' WHERE meta_key='sample.search_text';"
+UPDATE meta set meta_value='glycoprotein' WHERE meta_key='sample.search_text';"
 }
 
 #locations will now exist in meta as placholder info so replaces sql statesments with above ^
@@ -182,7 +182,7 @@ INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.gene_para
 INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.gene_text', 'ensembl_gene');
 INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.transcript_param', '".$sample_transcript->stable_id()."');
 INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.transcript_text', 'ensembl_transcript');
-INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.search_text', 'ensembl_gene');\n"
+INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.search_text', 'glycoprotein');\n"
 }
   else{
     print "No suitable transcripts found for $core_db\n";


### PR DESCRIPTION
Some basic fixes to the get_sample_genes script and it's registry:

script:
- use $ENV{ENSEMBL_RELEASE}; instead of hardcode
- remove dodgy closing parentheses  
- replace search.text with 'glycoprotein' (should be in all species and not cause duplication on species page)

registry:
- use ensro current compara database on ens-sta-1 only (i.e. not previous version of database and not on mirror)