### PR TITLE
Bug fix for downloading rnaseq data

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadRNASeqFastqs.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadRNASeqFastqs.pm
@@ -84,16 +84,25 @@ sub write_output {
 
   my $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$second_a/$srr/$fastq",  '-P', $path]);
   if ($res) {
-    $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$second_b/$srr/$fastq",  '-P', $path]);
-    if ($res) {
-      $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$srr/$fastq",  '-P', $path]);
+    $res >>= 8;
+    if ($res == 8) {
+      $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$second_b/$srr/$fastq",  '-P', $path]);
       if ($res) {
-	# if wget failed, delete the file so it can be downloaded again when retried
-	if (-e $path.'/'.$fastq) {
-	  $self->run_system_command(['rm',"$path/$fastq"]);
-	}
+        $res >>= 8;
+        if ($res == 8) {
+      	  $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$srr/$fastq",  '-P', $path]);
+          if ($res) {
+      	    $res >>= 8;
+            $self->throw("Could not download file $fastq error code is $res");
+            if ($res == 8) {
+              # if wget failed, delete the file so it can be downloaded again when retried
+              if (-e $path.'/'.$fastq) {
+                $self->run_system_command(['rm',"$path/$fastq"]);
+              }
+            }
+	  }
+        }
       }
-      $self->throw("Could not download file $fastq error code is $res");
     }
   }
   elsif ($res) {

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadRNASeqFastqs.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadRNASeqFastqs.pm
@@ -147,6 +147,17 @@ sub create_faidx {
   }
 }
 
+=head2 exit_code_test
+
+  Arg [1]    : Array, wget command
+               e.g. ['wget', '-qq', "$ftp_base_url/$first/$second_a/$srr/$fastq",  '-P', $path]
+  Description: The run_system_command returns a different exit code to wget
+               Here, run_system_command exit code is bit-shifted and tested (wget exit code for server error is 8)
+  Returntype : Boolean
+  Exceptions : Throws if error code not 8
+
+=cut
+
 sub exit_code_test {
   my ($self,$wget_cmd) = @_;
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadRNASeqFastqs.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadRNASeqFastqs.pm
@@ -84,28 +84,24 @@ sub write_output {
 
   my $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$second_a/$srr/$fastq",  '-P', $path]);
   if ($res) {
-    $res >>= 8;
-    if ($res == 8) {
-      $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$second_b/$srr/$fastq",  '-P', $path]);
-      if ($res == 8) {
-	$res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$srr/$fastq",  '-P', $path]);
-	if ($res) {
-	  $res >>= 8;
-	  # if wget failed, delete the file so it can be downloaded again when retried
-	  if (-e $path.'/'.$fastq) {
-	    $self->run_system_command(['rm',"$path/$fastq"]);
-	  }
-	  $self->throw("Could not download file $fastq error code is $res");
+    $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$second_b/$srr/$fastq",  '-P', $path]);
+    if ($res) {
+      $res = $self->run_system_command(['wget', '-qq', "$ftp_base_url/$first/$srr/$fastq",  '-P', $path]);
+      if ($res) {
+	# if wget failed, delete the file so it can be downloaded again when retried
+	if (-e $path.'/'.$fastq) {
+	  $self->run_system_command(['rm',"$path/$fastq"]);
 	}
       }
+      $self->throw("Could not download file $fastq error code is $res");
     }
-    elsif ($res) {
-      # if wget failed, delete the file so it can be downloaded again when retried
-      if (-e $path.'/'.$fastq) {
-        $self->run_system_command(['rm',"$path/$fastq"]);
-      }
-      $self->throw("wget died with error code $res");
+  }
+  elsif ($res) {
+    # if wget failed, delete the file so it can be downloaded again when retried
+    if (-e $path.'/'.$fastq) {
+      $self->run_system_command(['rm',"$path/$fastq"]);
     }
+    $self->throw("wget died with error code $res");
   }
 
   unless(-e $path.'/'.$fastq) {


### PR DESCRIPTION
The third url format was not working - code was only trying first and second formats - if statements were a bit dodgy. 

Tested this with the third format type (e.g. ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR413/SRR413775/), is working now.