### PR TITLE
Change web_data from perl hash to json format

### DIFF
--- a/scripts/genebuild/update_db_analysis_descriptions.pl
+++ b/scripts/genebuild/update_db_analysis_descriptions.pl
@@ -73,8 +73,10 @@ while (my @analysis_data = $sth_logic->fetchrow) {
     else {
       $web_data = '"'.$web_data.'"';
     }
+# convert the web_data back to json format
+    $web_data =~ s/\=\>/:/g;
     my $desc = $hash{'description'};
-    $desc =~ s/\'/\\\'/g;;
+    $desc =~ s/\'/\\\'/g;
 
     say "Creating SQL command for the analysis description table for logic_name ".$logic_name;
     my $insert = "INSERT INTO analysis_description (analysis_id, description, display_label, displayable, web_data) VALUES ($analysis_id, '$desc', '$hash{'display_label'}', $hash{'displayable'}, $web_data);";


### PR DESCRIPTION
The script produces a file with sql updates for the analysis_description table in an rnaseq database. The information for the updates is pulled from the Production database in JSON format. In order to manipulate the information, it is converted to a Perl hash.

The web_data is written like so:
`{'colour_key' => 'intron_support','zmenu' => 'Supporting_alignment',...`
i.e. looks like a Perl hash

The Perl hash format used to be ok for the web_data but now it needs to be in JSON format in order to match the Production db. The JSON format is the same as the Perl hash except with ":" in place of "=>", so I've simply added a sub line to deal with this.

Now the web_data is written like so:
`{'colour_key' : 'intron_support','zmenu' : 'Supporting_alignment',... `
i.e. looks like JSON

