### PR TITLE
Convert zeroes in DAF to NULL for external_db_id

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -8654,7 +8654,7 @@ sub pipeline_analyses {
         -parameters => {
                          db_conn => $self->o('rnaseq_refine_db'),
                          input_query => 'SELECT daf.* FROM dna_align_feature daf, analysis a WHERE daf.analysis_id = a.analysis_id AND a.logic_name != "rough_transcripts"',
-                         command_out => q(sort -nk2 -nk3 -nk4 | sed 's/NULL/\\N/g;s/^[0-9]\+/\\N/' > #daf_file#),
+                         command_out => q(sort -nk2 -nk3 -nk4 | sed 's/NULL/\\N/g;s/^[0-9]\+/\\N/' | awk -F ' ' '{$15="NULL"; print $0}' | sed 's/ /\t/g' > #daf_file#),
                          daf_file => $self->o('rnaseq_daf_introns_file'),
                          prepend => ['-NB', '-q'],
                        },


### PR DESCRIPTION
We got a report from Production that data checks will fail for the rnaseq dbs where there are zeroes in the external_db_id column of the DAF table - this is true for ALL our rnaseq dbs.

James patched the current rnaseq dbs https://github.com/Ensembl/staging-patches/pull/364/files.

**This is a fix for future rnaseq dbs**

The awk part: replaces the zeroes in the external_db_id column (column 15 in the rnaseq_daf_introns.dat file) with "NULL"

The sed part: reverts the spaces back to tabs