### PR TITLE
Allow species to contain the "sync" substring.

### DIFF
--- a/scripts/genebuild/create_annotation_configs.pl
+++ b/scripts/genebuild/create_annotation_configs.pl
@@ -747,7 +747,7 @@ sub init_pipeline {
 
 
     my $loop_command = $sync_command;
-    $loop_command =~ s/sync/loop \-sleep 0.3/;
+    $loop_command =~ s/\-sync/\-loop \-sleep 0.3/;
     my ($ehive_url) = $sync_command =~ /url\s+(\S+)/;
     my ($driver, $user, $password, $host, $port, $dbname) = $ehive_url =~ /^(\w+)[:\/]+(\w*):(\w+)@([^:]+):(\d+)\/(\w+)$/;
     if ($password) {


### PR DESCRIPTION
The commands are now generated correctly for species containing the "sync" substring.