### PR TITLE
Hotfix/ana desc json

### DIFF
--- a/scripts/genebuild/update_db_analysis_descriptions.pl
+++ b/scripts/genebuild/update_db_analysis_descriptions.pl
@@ -81,7 +81,7 @@ while (my @analysis_data = $sth_logic->fetchrow) {
     $desc =~ s/\'/\\\'/g;
 
     say "Creating SQL command for the analysis description table for logic_name ".$logic_name;
-    my $insert = "INSERT INTO analysis_description (analysis_id, description, display_label, displayable, web_data) VALUES ($analysis_id, '$desc', '$hash{'display_label'}', $hash{'displayable'}, $json_web_data);";
+    my $insert = "INSERT IGNORE INTO analysis_description (analysis_id, description, display_label, displayable, web_data) VALUES ($analysis_id, '$desc', '$hash{'display_label'}', $hash{'displayable'}, $json_web_data);";
     print OUT $insert."\n";
 
   }


### PR DESCRIPTION
When running the DCs on the cores, sometimes we got a failure because the web_data in our db did not match the web_data in the Production db. This was because of how I was handling the json format.
I've updated the json encoding, and it works now. Have tested and run through DCs.

Also, now that we run the Production pipelines and that adds some analysis descriptions, I have updated the sql to avoid duplicate errors (if you ran the production pipeline and then this script). 

@ndliberial @ens-carlos I've asked for you to review because you are/will be running DCs, so wanted to make sure you were aware of the change