### PR TITLE
Update hit_name_id in CMsearch.pm to prevent overly long names

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Runnable/CMSearch.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Runnable/CMSearch.pm
@@ -505,7 +505,7 @@ sub make_gene{
     -hcoverage    => $RNAfold->score,
     );
   
-  my $hit_name_id = $accession . "-" . $temp_id[2] . "/" . $daf->start . "-" . $daf->end;
+  my $hit_name_id = $accession . "/" . $daf->start . "-" . $daf->end;
 
   $daf = $new_daf;
   $daf->analysis($self->analysis);

--- a/modules/Bio/EnsEMBL/Analysis/Runnable/CMSearch.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Runnable/CMSearch.pm
@@ -505,7 +505,7 @@ sub make_gene{
     -hcoverage    => $RNAfold->score,
     );
   
-  my $hit_name_id = $accession . "/" . $daf->start . "-" . $daf->end;
+  my $hit_name_id = $accession;
 
   $daf = $new_daf;
   $daf->analysis($self->analysis);


### PR DESCRIPTION
Long names can exceed the character limit of the db field