### PR TITLE
Add analysis_description sync with production db to pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -76,6 +76,7 @@ sub default_options {
     'assembly_name'             => '', # Name (as it appears in the assembly report file)
     'assembly_accession'        => '', # Versioned GCA assembly accession, e.g. GCA_001857705.1
     'assembly_refseq_accession' => '', # Versioned GCF accession, e.g. GCF_001857705.1
+    'registry_file'             => '' || catfile($self->o('output_path'), "Databases.pm"), # Path to databse registry for LastaZ and Production sync
     'stable_id_prefix'          => '', # e.g. ENSPTR. When running a new annotation look up prefix in the assembly registry db
     'use_genome_flatfile'       => '1',# This will read sequence where possible from a dumped flatfile instead of the core db
     'species_url'               => '' || $self->o('production_name').$self->o('production_name_modifier'), # sets species.url meta key
@@ -97,7 +98,6 @@ sub default_options {
     'ig_tr_fasta_file'          => 'human_ig_tr.fa', # What IMGT fasta file to use. File should contain protein segments with appropriate headers
     'mt_accession'              => undef, # This should be set to undef unless you know what you are doing. If you specify an accession, then you need to add the parameters to the load_mitochondrion analysis
     'production_name_modifier'  => '', # Do not set unless working with non-reference strains, breeds etc. Must include _ in modifier, e.g. _hni for medaka strain HNI
-    'compara_registry_file'     => '',
 
     # Keys for custom loading, only set/modify if that's what you're doing
     'skip_genscan_blasts'          => '1',
@@ -135,7 +135,7 @@ sub default_options {
 # Pipe and ref db info
 ########################
 
-    'projection_source_db_name'    => 'homo_sapiens_core_96_38', # This is generally a pre-existing db, like the current human/mouse core for example
+    'projection_source_db_name'    => 'homo_sapiens_core_100_38', # This is generally a pre-existing db, like the current human/mouse core for example
     'projection_source_db_server'  => 'mysql-ens-mirror-1',
     'projection_source_db_port'    => '4240',
     'projection_source_production_name' => 'homo_sapiens',
@@ -535,7 +535,7 @@ sub default_options {
 
 # lincRNA pipeline stuff
     'lncrna_dir' => catdir($self->o('output_path'), 'lincrna'),
-    registry_file => catfile($self->o('lncrna_dir'), 'registry.pm'),
+    lncrna_registry_file => catfile($self->o('lncrna_dir'), 'registry.pm'),
     'file_translations' => catfile($self->o('lncrna_dir'), 'hive_dump_translations.fasta'),
     'file_for_length' => catfile($self->o('lncrna_dir'), 'check_lincRNA_length.out'),  # list of genes that are smaller than 200bp, if any
     'file_for_biotypes' => catfile($self->o('lncrna_dir'), 'check_lincRNA_need_to_update_biotype_antisense.out'), # mysql queries that will apply or not in your dataset (check update_database) and will update biotypes
@@ -1363,18 +1363,19 @@ sub pipeline_analyses {
 ###############################################################################
 
      {
-        -logic_name => 'download_rnaseq_csv',
-        -module     => 'Bio::EnsEMBL::Analysis::Hive::RunnableDB::HiveDownloadCsvENA',
-        -rc_name => '1GB',
+        -logic_name => 'create_registry',
+        -module     => 'Bio::EnsEMBL::Analysis::Hive::RunnableDB::CreateRegistry',
+        -rc_name => 'default',
         -parameters => {
-          study_accession => $self->o('study_accession'),
-          taxon_id => $self->o('species_taxon_id'),
-          inputfile => $self->o('rnaseq_summary_file'),
-	  paired_end_only => $self->o('paired_end_only'),
+                        compara_db => $self->o('compara_db'),
+                        projection_source_db => $self->o('projection_source_db'),
+                        target_db => $self->o('reference_db'),
+                        production_db => $self->o('production_db'),
+                        registry_file => $self->o('registry_file'),
         },
 
         -flow_into => {
-           1 => ['download_genus_rnaseq_csv'],
+           1 => ['download_rnaseq_csv'],
          },
 
         -input_ids  => [
@@ -1384,6 +1385,22 @@ sub pipeline_analyses {
             assembly_refseq_accession => $self->o('assembly_refseq_accession'),
           },
         ]
+      },
+
+      {
+        -logic_name => 'download_rnaseq_csv',
+        -module     => 'Bio::EnsEMBL::Analysis::Hive::RunnableDB::HiveDownloadCsvENA',
+        -rc_name => '1GB',
+        -parameters => {
+          study_accession => $self->o('study_accession'),
+          taxon_id => $self->o('species_taxon_id'),
+          inputfile => $self->o('rnaseq_summary_file'),
+          paired_end_only => $self->o('paired_end_only'),
+        },
+
+	-flow_into => {
+           1 => ['download_genus_rnaseq_csv'],
+         },
       },
 
 
@@ -3406,6 +3423,7 @@ sub pipeline_analyses {
                          pipeline_db => $self->o('pipeline_db'),
                          output_path => $self->o('output_path'),
                          compara_db_url => 'mysql://'.$self->o('user').':'.$self->o('password').'@'.$self->o('compara_db_server').':'.$self->o('compara_db_port').'/'.$self->o('compara_db_name'),
+                         registry_file => $self->o('registry_file'),
                        },
 
         -rc_name => '2GB_lastz',
@@ -8286,6 +8304,19 @@ sub pipeline_analyses {
                        },
         -rc_name    => 'default',
         -flow_into => {
+                       1 => ['populate_analysis_descriptions'],
+        },
+      },
+
+      {
+        -logic_name => 'populate_analysis_descriptions',
+        -module     => 'Bio::EnsEMBL::Production::Pipeline::ProductionDBSync::PopulateAnalysisDescription',
+        -parameters => {
+                        species => $self->o('species_name'),
+                        group => 'core',
+                       },
+        -rc_name    => 'default_registry',
+        -flow_into => {
                        1 => ['core_gene_set_sanity_checks'],
         },
       },
@@ -9059,20 +9090,20 @@ sub resource_classes {
 
   return {
     '1GB' => { LSF => $self->lsf_resource_builder('production-rh74', 1000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
-    '2GB_lastz' => { LSF => [$self->lsf_resource_builder('production-rh74', 2000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}]), '-reg_conf '.$self->default_options->{compara_registry_file}]},
+    '2GB_lastz' => { LSF => [$self->lsf_resource_builder('production-rh74', 2000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}]), '-reg_conf '.$self->default_options->{registry_file}]},
     '2GB' => { LSF => $self->lsf_resource_builder('production-rh74', 2000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
     '3GB' => { LSF => $self->lsf_resource_builder('production-rh74', 3000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
-    '4GB_lastz' => { LSF => [$self->lsf_resource_builder('production-rh74', 4000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}]), '-reg_conf '.$self->default_options->{compara_registry_file}]}, 
+    '4GB_lastz' => { LSF => [$self->lsf_resource_builder('production-rh74', 4000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}]), '-reg_conf '.$self->default_options->{registry_file}]}, 
     '4GB' => { LSF => $self->lsf_resource_builder('production-rh74', 4000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
     '5GB' => { LSF => $self->lsf_resource_builder('production-rh74', 5000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
     '6GB' => { LSF => $self->lsf_resource_builder('production-rh74', 6000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
     '6GB_registry' => { LSF => [$self->lsf_resource_builder('production-rh74', 6000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}]), '-reg_conf '.$self->default_options->{registry_file}]},
     '7GB' => { LSF => $self->lsf_resource_builder('production-rh74', 7000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
-    '8GB_lastz' => { LSF => [$self->lsf_resource_builder('production-rh74', 8000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}]), '-reg_conf '.$self->default_options->{compara_registry_file}]},
+    '8GB_lastz' => { LSF => [$self->lsf_resource_builder('production-rh74', 8000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}]), '-reg_conf '.$self->default_options->{registry_file}]},
     '8GB' => { LSF => $self->lsf_resource_builder('production-rh74', 8000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
     '9GB' => { LSF => $self->lsf_resource_builder('production-rh74', 9000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
     '10GB' => { LSF => $self->lsf_resource_builder('production-rh74', 10000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
-    '15GB_lastz' => { LSF => [$self->lsf_resource_builder('production-rh74', 15000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}]), '-reg_conf '.$self->default_options->{compara_registry_file}]},
+    '15GB_lastz' => { LSF => [$self->lsf_resource_builder('production-rh74', 15000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}]), '-reg_conf '.$self->default_options->{registry_file}]},
     '15GB' => { LSF => $self->lsf_resource_builder('production-rh74', 15000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
     '20GB' => { LSF => $self->lsf_resource_builder('production-rh74', 20000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
     '25GB' => { LSF => $self->lsf_resource_builder('production-rh74', 25000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
@@ -9084,6 +9115,7 @@ sub resource_classes {
     '80GB' => { LSF => $self->lsf_resource_builder('production-rh74', 80000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
     '100GB' => { LSF => $self->lsf_resource_builder('production-rh74', 100000, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
     'default' => { LSF => $self->lsf_resource_builder('production-rh74', 900, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
+    'default_registry' => { LSF => [$self->lsf_resource_builder('production-rh74', 900, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}]), '-reg_conf '.$self->default_options->{registry_file}]},
     'repeatmasker' => { LSF => $self->lsf_resource_builder('production-rh74', 2900, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
     'repeatmasker_rebatch' => { LSF => $self->lsf_resource_builder('production-rh74', 5900, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},
     'simple_features' => { LSF => $self->lsf_resource_builder('production-rh74', 2900, [$self->default_options->{'pipe_db_server'}, $self->default_options->{'dna_db_server'}], [$self->default_options->{'num_tokens'}])},

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/CreateRegistry.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/CreateRegistry.pm
@@ -24,14 +24,14 @@ Questions may also be sent to the Ensembl help desk at
 
 =head1 NAME
 
-Bio::EnsEMBL::Analysis::Hive::RunnableDB::HiveLoadmRNAs
+Bio::EnsEMBL::Analysis::Hive::RunnableDB::CreateRegistry
 
 =head1 SYNOPSIS
 
 
 =head1 DESCRIPTION
 
-Module to load mRNA into a customised table in the Hive database
+Create registry file for use in different parts of the pipeline (LastZ, Loading analysis descriptions from Produciton db)
 
 =cut
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/CreateRegistry.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/CreateRegistry.pm
@@ -1,0 +1,180 @@
+=head1 LICENSE
+
+Copyright [2019-2020] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=head1 CONTACT
+
+Please email comments or questions to the public Ensembl
+developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+Questions may also be sent to the Ensembl help desk at
+<http://www.ensembl.org/Help/Contact>.
+
+=head1 NAME
+
+Bio::EnsEMBL::Analysis::Hive::RunnableDB::HiveLoadmRNAs
+
+=head1 SYNOPSIS
+
+
+=head1 DESCRIPTION
+
+Module to load mRNA into a customised table in the Hive database
+
+=cut
+
+package Bio::EnsEMBL::Analysis::Hive::RunnableDB::CreateRegistry;
+
+use warnings;
+use strict;
+use feature 'say';
+
+use parent ('Bio::EnsEMBL::Analysis::Hive::RunnableDB::HiveBaseRunnableDB');
+
+=head2 fetch_input
+
+ Arg [1]    : None
+ Description: Set db connections
+ Returntype : None
+ Exceptions : None
+
+=cut
+
+sub fetch_input {
+  my ($self) = @_;
+
+  my $compara_dba = $self->hrdb_get_dba($self->param_required('compara_db'),undef,'Compara');
+  $self->hrdb_set_con($compara_dba,'compara_db');
+
+  my $target_dba = $self->hrdb_get_dba($self->param_required('target_db'));
+  $self->hrdb_set_con($target_dba,'target_db');
+
+  my $projection_source_dba = $self->hrdb_get_dba($self->param_required('projection_source_db'));
+  $self->hrdb_set_con($projection_source_dba,'projection_source_db');
+
+  my $production_dba = $self->hrdb_get_dba($self->param_required('production_db'),undef,'Production');
+  $self->hrdb_set_con($production_dba,'production_db');
+
+}
+
+=head2 run
+
+ Arg [1]    : None
+ Description: Create registry file, Databases.pm
+ Returntype : None
+ Exceptions : None
+
+=cut
+
+sub run {
+  my ($self) = @_;
+
+  my $compara_dba =  $self->hrdb_get_con('compara_db');
+  my $target_dba = $self->hrdb_get_con('target_db');
+  my $projection_source_dba = $self->hrdb_get_con('projection_source_db');
+  my $production_dba = $self->hrdb_get_con('production_db');
+
+  my $source_production_name = $projection_source_dba->get_MetaContainer->get_production_name();
+  my $target_production_name = $target_dba->get_MetaContainer->get_production_name();
+
+  my $compara_dbname = $compara_dba->dbc->dbname;
+  my $compara_host = $compara_dba->dbc->host;
+  my $compara_port = $compara_dba->dbc->port;
+  my $compara_user = $compara_dba->dbc->user;
+  my $compara_pass = $compara_dba->dbc->pass;
+
+  my $target_dbname = $target_dba->dbc->dbname;
+  my $target_host = $target_dba->dbc->host;
+  my $target_port = $target_dba->dbc->port;
+  my $target_user = $target_dba->dbc->user;
+  my $target_pass = $target_dba->dbc->pass;
+
+  my $source_dbname = $projection_source_dba->dbc->dbname;
+  my $source_host = $projection_source_dba->dbc->host;
+  my $source_port = $projection_source_dba->dbc->port;
+  my $source_user = $projection_source_dba->dbc->user;
+  my $source_pass = $projection_source_dba->dbc->pass;
+
+  my $production_dbname = $production_dba->dbc->dbname;
+  my $production_host = $production_dba->dbc->host;
+  my $production_port = $production_dba->dbc->port;
+  my $production_user = $production_dba->dbc->user;
+  my $production_pass = $production_dba->dbc->pass;
+
+my $reg_path = $self->param_required('registry_file');
+  open(OUT,">".$reg_path);
+  say OUT <<DATABASES
+  use warnings;
+  use strict;
+
+  use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
+  use Bio::EnsEMBL::Production::DBSQL::DBAdaptor;
+
+  # Target species
+  Bio::EnsEMBL::Registry->load_registry_from_url('mysql://$target_user:$target_pass\@$target_host:$target_port/$target_dbname?group=core&species=$target_production_name');
+
+  # Reference species
+  Bio::EnsEMBL::Registry->load_registry_from_url('mysql://$source_user:$source_pass\@$source_host:$source_port/$source_dbname?group=core&species=$source_production_name');
+
+  Bio::EnsEMBL::DBSQL::DBAdaptor->new(
+    -host    => '$source_host',
+    -user    => '$source_user',
+    -port    => $source_port,
+    -species => '$source_production_name',
+    -group   => 'core',
+    -dbname  => '$source_dbname',
+    -pass    => '$source_pass',
+ );
+
+  # Compara master database:
+  Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->new(
+    -host    => '$compara_host',
+    -user    => '$compara_user',
+    -port    => $compara_port,
+    -species => 'compara_master',
+    -dbname  => '$compara_dbname',
+    -pass    => '$compara_pass',
+  );
+
+  # Production db
+  Bio::EnsEMBL::Production::DBSQL::DBAdaptor->new(
+    -host    => '$production_host',
+    -port    => $production_port,
+    -user    => '$production_user',
+    -dbname  => '$production_dbname',
+    -species => 'multi',
+    -group   => 'production',
+  );
+
+  1;
+DATABASES
+  ;
+
+}
+
+=head2 write_output
+
+ Arg [1]    : None
+ Description: Nothing to do here
+ Returntype : None
+ Exceptions : None
+
+=cut
+
+sub write_output {
+
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/LastZSetup.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/LastZSetup.pm
@@ -78,7 +78,7 @@ sub run {
   my $databases_conf_path = $self->param_required('registry_path');
 
   unless($databases_conf_path) {
-    $self->throw($registry_path." does not exist");
+    $self->throw($databases_conf_path." does not exist");
   }
 
   my $update_genome_db_cmd = 'perl '.$self->param_required('compara_genome_db_update_path').

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/LastZSetup.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/LastZSetup.pm
@@ -75,15 +75,11 @@ sub run {
   my $target_assembly_name = $target_dba->get_MetaContainer->single_value_by_key('assembly.default');
   my $source_production_name = $projection_source_dba->get_MetaContainer->get_production_name();
   my $target_production_name = $target_dba->get_MetaContainer->get_production_name();
+  my $databases_conf_path = $self->param_required('registry_path');
 
-  say "Creating Databases.pm";
-  my $databases_conf_path = $self->create_compara_databases_conf($source_production_name,$target_production_name,$compara_dba,$target_dba,$projection_source_dba);
   unless($databases_conf_path) {
-    $self->throw("Could not create a Databases.pm registry");
+    $self->throw($registry_path." does not exist");
   }
-  say "...finished creating Databases.pm";
-
-  $self->param('reg_conf',$databases_conf_path);
 
   my $update_genome_db_cmd = 'perl '.$self->param_required('compara_genome_db_update_path').
                              ' --reg_conf '.$databases_conf_path.
@@ -180,78 +176,6 @@ sub run {
 
 sub write_output {
   my ($self) = @_;
-}
-
-
-sub create_compara_databases_conf {
-  my ($self,$source_production_name,$target_production_name,$compara_dba,$target_dba,$source_dba) = @_;
-
-  my $target_dbname = $target_dba->dbc->dbname;
-  my $target_host = $target_dba->dbc->host;
-  my $target_port = $target_dba->dbc->port;
-  my $target_user = $target_dba->dbc->user;
-  my $target_pass = $target_dba->dbc->pass;
-
-  my $source_dbname = $source_dba->dbc->dbname;
-  my $source_host = $source_dba->dbc->host;
-  my $source_port = $source_dba->dbc->port;
-  my $source_user = $source_dba->dbc->user;
-  my $source_pass = $source_dba->dbc->pass;
-
-  my $compara_dbname = $compara_dba->dbc->dbname;
-  my $compara_host = $compara_dba->dbc->host;
-  my $compara_port = $compara_dba->dbc->port;
-  my $compara_user = $compara_dba->dbc->user;
-  my $compara_pass = $compara_dba->dbc->pass;
-
-
-  my $conf_path = $self->param_required('output_path')."/Databases.pm";
-  open(OUT,">".$conf_path);
-  say OUT <<DATABASES
-  use warnings;
-  use strict;
-
-  use Bio::EnsEMBL::Compara::DBSQL::DBAdaptor;
-  use Bio::EnsEMBL::DBSQL::DBAdaptor;
-
-  # Target species
-  Bio::EnsEMBL::DBSQL::DBAdaptor->new(
-    -host    => '$target_host',
-    -user    => '$target_user',
-    -port    => $target_port,
-    -species => '$target_production_name',
-    -group   => 'core',
-    -dbname  => '$target_dbname',
-    -pass    => '$target_pass',
-  );
-
-  # Reference species
-  Bio::EnsEMBL::DBSQL::DBAdaptor->new(
-    -host    => '$source_host',
-    -user    => '$source_user',
-    -port    => $source_port,
-    -species => '$source_production_name',
-    -group   => 'core',
-    -dbname  => '$source_dbname',
-    -pass    => '$source_pass',
-  );
-
-  # Compara master database:
-  Bio::EnsEMBL::Compara::DBSQL::DBAdaptor->new(
-    -host    => '$compara_host',
-    -user    => '$compara_user',
-    -port    => $compara_port,
-    -species => 'compara_master',
-    -dbname  => '$compara_dbname',
-    -pass    => '$compara_pass',
-  );
-
-  1;
-DATABASES
-;
-
-  close OUT;
-  return($conf_path);
 }
 
 

--- a/scripts/genebuild/create_annotation_configs.pl
+++ b/scripts/genebuild/create_annotation_configs.pl
@@ -469,7 +469,7 @@ sub parse_assembly_report {
 sub create_config {
   my ($assembly_hash) = @_;
 
-  $assembly_hash->{'compara_registry_file'} = catfile($assembly_hash->{'output_path'},$assembly_hash->{'accession'},"Databases.pm");
+  $assembly_hash->{'registry_path'} = catfile($assembly_hash->{'output_path'},"Databases.pm");
 
   foreach my $key (keys(%{$assembly_hash})) {
     say "ASSEMBLY: ". $key." => ".$assembly_hash->{$key};


### PR DESCRIPTION
Previously updated the pipeline to fix the analysis table. Running the production sync pipeline would then add the analysis descriptions.

Here I have incorporated the Production populate_analysis_descriptions module in to the pipeline. 

It requires a registry file, since one is created for the LastZ pipeline, it seemed redundant to create another. Instead the first module, create_registry, will create the registry containing database info for the LastZ and analysis_decription parts of the pipeline. 
The code to create the registry has been removed from the SetupLastz.pm code and a new CreateRegistry.pm module has been created.

Happy to discuss this further in a meeting. 
