### PR TITLE
Updated regex for RFAM DAF

### DIFF
--- a/scripts/genebuild/daf_regexes.dat
+++ b/scripts/genebuild/daf_regexes.dat
@@ -77,7 +77,7 @@
 '^EFR[mnxyz][0-9]*[a-z]*[A-Z]*[0-9]*$'	TakRub_est
 '^Fe:e[A-Z]{2}[0-9]{6}$'	TakRub_cdna
 '^MI[0-9]{7}$'	miRBase
-'^RF[0-9]{5}-[A-Z0-9].*'	RFAM
+'^RF[0-9]{5}-*[A-Z0-9]*.*'	RFAM
 '\.[0-9]*-[0-9]*$'	IMGT/LIGM_DB
 '^oa-OR.*$'	Platypus_olfactory_receptor
 '^Plat_OR[0-9]+$'	Platypus_olfactory_receptor

--- a/scripts/genebuild/daf_regexes.dat
+++ b/scripts/genebuild/daf_regexes.dat
@@ -78,6 +78,7 @@
 '^Fe:e[A-Z]{2}[0-9]{6}$'	TakRub_cdna
 '^MI[0-9]{7}$'	miRBase
 '^RF[0-9]{5}-*[A-Z0-9]*.*'	RFAM
+'^RF[0-9]{5}/[0-9]+-[0-9]+$' RFAM
 '\.[0-9]*-[0-9]*$'	IMGT/LIGM_DB
 '^oa-OR.*$'	Platypus_olfactory_receptor
 '^Plat_OR[0-9]+$'	Platypus_olfactory_receptor


### PR DESCRIPTION
Hit names were recently updated for cmsearch https://github.com/Ensembl/ensembl-analysis/pull/106, the regex for this was no longer working. Have updated regex - should work for both formats.
