### PR TITLE
Change rename_file default value to 1

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -5685,6 +5685,7 @@ sub pipeline_analyses {
           samtools => $self->o('samtools_path'),
           picard_lib_jar => $self->o('picard_lib_jar'),
           use_threads => $self->o('rnaseq_merge_threads'),
+          rename_file => 1,
         },
         -rc_name    => '3GB_merged_multithread',
         -flow_into => {

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveMergeBamFiles.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveMergeBamFiles.pm
@@ -103,7 +103,7 @@ sub param_defaults {
   return {
     %{$self->SUPER::param_defaults()},
     bam_version => 1,
-    rename_file => 1,
+    rename_file => 0,
     store_datafile => 1,
     _index_ext => 'bai',
     _file_ext => 'bam',

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveMergeBamFiles.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveMergeBamFiles.pm
@@ -103,7 +103,7 @@ sub param_defaults {
   return {
     %{$self->SUPER::param_defaults()},
     bam_version => 1,
-    rename_file => 0,
+    rename_file => 1,
     store_datafile => 1,
     _index_ext => 'bai',
     _file_ext => 'bam',


### PR DESCRIPTION
Where there is only one bam file for a given tissue the SRR*.bam file should be copied to the merge directory. For some reason the default value for rename_file was set to 0 and should be set to 1, in order to copy the SRR*.bam file.
