### PR TITLE
Updated populate_analysis_description  for non-reference assemblies

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -8292,7 +8292,7 @@ sub pipeline_analyses {
         -logic_name => 'populate_analysis_descriptions',
         -module     => 'Bio::EnsEMBL::Production::Pipeline::ProductionDBSync::PopulateAnalysisDescription',
         -parameters => {
-                        species => $self->o('species_name'),
+                        species => $self->o('production_name'),
                         group => 'core',
                        },
         -rc_name    => 'default_registry',


### PR DESCRIPTION
Updated populate_analysis_description to use production_name as species. This allows the pipeline to identify the species in the production db especially when dealing with non-reference assemblies