### PR TITLE
Update to main config to run long read module by default

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -87,7 +87,7 @@ sub default_options {
     'skip_projection'           => '0', # Will skip projection process if 1
     'skip_lastz'                => '0', # Will skip lastz if 1 (if skip_projection is enabled this is irrelevant)
     'skip_rnaseq'               => '0', # Will skip rnaseq analyses if 1
-    'skip_long_read'            => '1', # Will skip long read analyses if 1
+    'skip_long_read'            => '0', # Will skip long read analyses if 1
     'skip_ncrna'                => '0', # Will skip ncrna process if 1
     'skip_cleaning'             => '0', # Will skip the cleaning phase, will keep more genes/transcripts but some lower quality models may be kept
     'mapping_required'          => '0', # If set to 1 this will run stable_id mapping sometime in the future. At the moment it does nothing
@@ -6704,7 +6704,7 @@ sub pipeline_analyses {
         -logic_name => 'fan_long_read',
         -module => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
         -parameters => {
-                         cmd => 'if [ "#skip_long_read#" -ne "0" ]; then exit 42; else exit 0;fi',
+                         cmd => 'if [ "#skip_long_read#" -eq "0" ] && [ -e "'.$self->o('long_read_summary_file').'" ] || [ -e "'.$self->o('long_read_summary_file_genus').'" ]; then exit 0; else exit 42;fi',
                          return_codes_2_branches => {'42' => 2},
 	},
         -flow_into  => {


### PR DESCRIPTION
By default the long read module was set to skip. This update reverses that to allow pipeline to check if long read data exists or not before deciding whether to run. This has been tested.