### PR TITLE
Meta key changes for Rapid Release

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -359,7 +359,6 @@ sub default_options {
     assembly_name_script       => catfile($self->o('ensembl_analysis_script'), 'update_assembly_name.pl'),
 
     rnaseq_daf_introns_file => catfile($self->o('output_dir'), 'rnaseq_daf_introns.dat'),
-    bad_common_name_file    => catfile($self->o('ensembl_analysis_script'), 'genebuild', 'bad_common_names.txt'), # File containing ncbi taxonomy common names that are too generic to be used in the core db
 
     # Genes biotypes to ignore from the final db when copying to core
     copy_biotypes_to_ignore => {
@@ -1544,7 +1543,6 @@ sub pipeline_analyses {
           full_ftp_path => $self->o('assembly_ftp_path'),
           output_path   => $self->o('output_path'),
           target_db     => $self->o('reference_db'),
-          bad_common_name_file => $self->o('bad_common_name_file'),
         },
         -rc_name    => '8GB',
 	-max_retry_count => 0,

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -155,8 +155,6 @@ sub default_options {
     'assembly_provider_url'         => '',
     'annotation_provider_name'      => 'Ensembl',
     'annotation_provider_url'       => 'www.ensembl.org',
-    'strain_type'                   => 'strain',
-    'strain'                        => 'reference',
 
     'pipe_db_name'                  => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_pipe_'.$self->o('release_number'),
     'dna_db_name'                   => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_core_'.$self->o('release_number'),
@@ -362,6 +360,7 @@ sub default_options {
     assembly_name_script       => catfile($self->o('ensembl_analysis_script'), 'update_assembly_name.pl'),
 
     rnaseq_daf_introns_file => catfile($self->o('output_dir'), 'rnaseq_daf_introns.dat'),
+    bad_common_name_file    => catfile($self->o('ensembl_analysis_script'), 'genebuild', 'bad_common_names.txt'), # File containing ncbi taxonomy common names that are too generic to be used in the core db
 
     # Genes biotypes to ignore from the final db when copying to core
     copy_biotypes_to_ignore => {
@@ -1546,6 +1545,7 @@ sub pipeline_analyses {
           full_ftp_path => $self->o('assembly_ftp_path'),
           output_path   => $self->o('output_path'),
           target_db     => $self->o('reference_db'),
+          bad_common_name_file => $self->o('bad_common_name_file'),
         },
         -rc_name    => '8GB',
 	-max_retry_count => 0,
@@ -1579,9 +1579,7 @@ sub pipeline_analyses {
               ($self->o('use_repeatmodeler_to_mask') ? '(1, "repeat.analysis", "'.$self->o('repeatmodeler_logic_name').'"),': '').
               '(1, "repeat.analysis", "dust"),'.
               '(1, "repeat.analysis", "trf"),'.
-              '(1, "strain.type", "'.$self->o('strain_type').'"),'.
-              '(1, "species.strain_group", "'.$self->o('production_name').'"),'.
-              '(1, "species.strain", "'.$self->o('strain').'")',
+              '(1, "species.strain_group", "'.$self->o('production_name').'")',
           ],
         },
         -rc_name    => 'default',
@@ -1718,9 +1716,6 @@ sub pipeline_analyses {
             'repeat.analysis' => [$self->o('full_repbase_logic_name'), 'dust', 'trf'],
             'species.production_name' => $self->o('production_name').$self->o('production_name_modifier'),
             'species.taxonomy_id' => $self->o('taxon_id'),
-            'strain.type' => $self->o('strain_type'),
-            'species.strain_group' => $self->o('production_name'),
-            'species.strain' => $self->o('strain'),
           }
         },
         -rc_name => 'default',

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -43,7 +43,7 @@ sub default_options {
 # Misc setup info
 ########################
     'dbowner'                   => '' || $ENV{EHIVE_USER} || $ENV{USER},
-    'pipeline_name'             => '' || $self->o('production_name').$self->o('production_name_modifier').'_'.$self->o('ensembl_release'),
+    'pipeline_name'             => '' || $self->o('production_name').'_'.$self->o('ensembl_release'),
     'user_r'                    => '', # read only db user
     'user'                      => '', # write db user
     'password'                  => '', # password for write db user
@@ -66,7 +66,7 @@ sub default_options {
     'long_read_fastq_dir'       => '' || catdir($self->o('long_read_dir'),'input'),
     'release_number'            => '' || $self->o('ensembl_release'),
     'species_name'              => '', # e.g. mus_musculus
-    'production_name'           => '' || $self->o('species_name'), # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    'production_name'           => '', # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
     'taxon_id'                  => '', # should be in the assembly report file
     'species_taxon_id'          => '' || $self->o('taxon_id'), # Species level id, could be different to taxon_id if we have a subspecies, used to get species level RNA-seq CSV data
     'genus_taxon_id'            => '' || $self->o('taxon_id'), # Genus level taxon id, used to get a genus level csv file in case there is not enough species level transcriptomic data
@@ -79,7 +79,7 @@ sub default_options {
     'registry_file'             => '' || catfile($self->o('output_path'), "Databases.pm"), # Path to databse registry for LastaZ and Production sync
     'stable_id_prefix'          => '', # e.g. ENSPTR. When running a new annotation look up prefix in the assembly registry db
     'use_genome_flatfile'       => '1',# This will read sequence where possible from a dumped flatfile instead of the core db
-    'species_url'               => '' || $self->o('production_name').$self->o('production_name_modifier'), # sets species.url meta key
+    'species_url'               => '', # sets species.url meta key
     'species_division'          => 'EnsemblVertebrates', # sets species.division meta key
     'stable_id_start'           => '0', # When mapping is not required this is usually set to 0
     'skip_repeatmodeler'        => '0', # Skip using our repeatmodeler library for the species with repeatmasker, will still run standard repeatmasker
@@ -97,7 +97,6 @@ sub default_options {
     'paired_end_only'           => '1', # Will only use paired-end rnaseq data if 1
     'ig_tr_fasta_file'          => 'human_ig_tr.fa', # What IMGT fasta file to use. File should contain protein segments with appropriate headers
     'mt_accession'              => undef, # This should be set to undef unless you know what you are doing. If you specify an accession, then you need to add the parameters to the load_mitochondrion analysis
-    'production_name_modifier'  => '', # Do not set unless working with non-reference strains, breeds etc. Must include _ in modifier, e.g. _hni for medaka strain HNI
 
     # Keys for custom loading, only set/modify if that's what you're doing
     'skip_genscan_blasts'          => '1',
@@ -156,8 +155,8 @@ sub default_options {
     'annotation_provider_name'      => 'Ensembl',
     'annotation_provider_url'       => 'www.ensembl.org',
 
-    'pipe_db_name'                  => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_pipe_'.$self->o('release_number'),
-    'dna_db_name'                   => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_core_'.$self->o('release_number'),
+    'pipe_db_name'                  => $self->o('dbowner').'_'.$self->o('production_name').'_pipe_'.$self->o('release_number'),
+    'dna_db_name'                   => $self->o('dbowner').'_'.$self->o('production_name').'_core_'.$self->o('release_number'),
 
     'reference_db_name'            => $self->o('dna_db_name'),
     'reference_db_server'          => $self->o('dna_db_server'),
@@ -240,7 +239,7 @@ sub default_options {
 
     'ncrna_db_server'              => $self->o('databases_server'),
     'ncrna_db_port'                => $self->o('databases_port'),
-    ncrna_db_name                  => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_ncrna_'.$self->o('release_number'),
+    ncrna_db_name                  => $self->o('dbowner').'_'.$self->o('production_name').'_ncrna_'.$self->o('release_number'),
 
     'final_geneset_db_server'      => $self->o('databases_server'),
     'final_geneset_db_port'        => $self->o('databases_port'),
@@ -820,7 +819,7 @@ sub default_options {
 
 
     'cdna_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_cdna_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_cdna_'.$self->o('release_number'),
       -host   => $self->o('cdna_db_server'),
       -port   => $self->o('cdna_db_port'),
       -user   => $self->o('user'),
@@ -830,7 +829,7 @@ sub default_options {
 
 
     'genblast_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_genblast_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_genblast_'.$self->o('release_number'),
       -host   => $self->o('genblast_db_server'),
       -port   => $self->o('genblast_db_port'),
       -user   => $self->o('user'),
@@ -840,7 +839,7 @@ sub default_options {
 
 
     'genblast_nr_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_genblast_nr_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_genblast_nr_'.$self->o('release_number'),
       -host   => $self->o('genblast_db_server'),
       -port   => $self->o('genblast_db_port'),
       -user   => $self->o('user'),
@@ -850,7 +849,7 @@ sub default_options {
 
 
     'genblast_rnaseq_support_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_genblast_rnaseq_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_genblast_rnaseq_'.$self->o('release_number'),
       -host   => $self->o('genblast_rnaseq_support_db_server'),
       -port   => $self->o('genblast_rnaseq_support_db_port'),
       -user   => $self->o('user'),
@@ -860,7 +859,7 @@ sub default_options {
 
 
     'genblast_rnaseq_support_nr_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_genblast_rnaseq_nr_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_genblast_rnaseq_nr_'.$self->o('release_number'),
       -host   => $self->o('genblast_rnaseq_support_db_server'),
       -port   => $self->o('genblast_rnaseq_support_db_port'),
       -user   => $self->o('user'),
@@ -870,7 +869,7 @@ sub default_options {
 
 
     'ig_tr_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_igtr_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_igtr_'.$self->o('release_number'),
       -host   => $self->o('ig_tr_db_server'),
       -port   => $self->o('ig_tr_db_port'),
       -user   => $self->o('user'),
@@ -879,7 +878,7 @@ sub default_options {
     },
 
     cdna2genome_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_cdna2genome_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_cdna2genome_'.$self->o('release_number'),
       -host   => $self->o('cdna2genome_db_server'),
       -port   => $self->o('cdna2genome_db_port'),
       -user   => $self->o('user'),
@@ -888,7 +887,7 @@ sub default_options {
     },
 
     'genewise_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_genewise_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_genewise_'.$self->o('release_number'),
       -host   => $self->o('genewise_db_server'),
       -port   => $self->o('genewise_db_port'),
       -user   => $self->o('user'),
@@ -897,7 +896,7 @@ sub default_options {
     },
 
     'best_targeted_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_bt_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_bt_'.$self->o('release_number'),
       -host   => $self->o('genewise_db_server'),
       -port   => $self->o('genewise_db_port'),
       -user   => $self->o('user'),
@@ -906,7 +905,7 @@ sub default_options {
     },
 
     long_read_initial_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_lrinitial_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_lrinitial_'.$self->o('release_number'),
       -host   => $self->o('long_read_initial_db_server'),
       -port   => $self->o('long_read_initial_db_port'),
       -user   => $self->o('user'),
@@ -915,7 +914,7 @@ sub default_options {
     },
 
     long_read_collapse_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_lrcollapse_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_lrcollapse_'.$self->o('release_number'),
       -host => $self->o('long_read_collapse_db_server'),
       -port => $self->o('long_read_collapse_db_port'),
       -user => $self->o('user'),
@@ -924,7 +923,7 @@ sub default_options {
     },
 
     long_read_blast_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_lrblast_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_lrblast_'.$self->o('release_number'),
       -host => $self->o('long_read_blast_db_server'),
       -port => $self->o('long_read_blast_db_port'),
       -user => $self->o('user'),
@@ -933,7 +932,7 @@ sub default_options {
     },
 
     long_read_final_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_lrfinal_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_lrfinal_'.$self->o('release_number'),
       -host => $self->o('long_read_final_db_server'),
       -port => $self->o('long_read_final_db_port'),
       -user => $self->o('user'),
@@ -942,7 +941,7 @@ sub default_options {
     },
 
     'projection_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_proj_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_proj_'.$self->o('release_number'),
       -host   => $self->o('projection_db_server'),
       -port   => $self->o('projection_db_port'),
       -user   => $self->o('user'),
@@ -951,7 +950,7 @@ sub default_options {
     },
 
     'selected_projection_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_sel_proj_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_sel_proj_'.$self->o('release_number'),
       -host   => $self->o('projection_db_server'),
       -port   => $self->o('projection_db_port'),
       -user   => $self->o('user'),
@@ -960,7 +959,7 @@ sub default_options {
     },
 
     'projection_realign_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_realign_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_realign_'.$self->o('release_number'),
       -host   => $self->o('projection_realign_db_server'),
       -port   => $self->o('projection_realign_db_port'),
       -user   => $self->o('user'),
@@ -969,7 +968,7 @@ sub default_options {
     },
 
     'projection_lincrna_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_proj_linc_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_proj_linc_'.$self->o('release_number'),
       -host   => $self->o('projection_lincrna_db_server'),
       -port   => $self->o('projection_lincrna_db_port'),
       -user   => $self->o('user'),
@@ -978,7 +977,7 @@ sub default_options {
     },
 
     'projection_pseudogene_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_proj_pseudo_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_proj_pseudo_'.$self->o('release_number'),
       -host   => $self->o('projection_pseudogene_db_server'),
       -port   => $self->o('projection_pseudogene_db_port'),
       -user   => $self->o('user'),
@@ -1005,7 +1004,7 @@ sub default_options {
     },
 
     'rnaseq_for_layer_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_rnaseq_layer_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_rnaseq_layer_'.$self->o('release_number'),
       -host   => $self->o('rnaseq_for_layer_db_server'),
       -port   => $self->o('rnaseq_for_layer_db_port'),
       -user   => $self->o('user'),
@@ -1015,7 +1014,7 @@ sub default_options {
 
 
     'rnaseq_for_layer_nr_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_rnaseq_layer_nr_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_rnaseq_layer_nr_'.$self->o('release_number'),
       -host   => $self->o('rnaseq_for_layer_db_server'),
       -port   => $self->o('rnaseq_for_layer_db_port'),
       -user   => $self->o('user'),
@@ -1024,7 +1023,7 @@ sub default_options {
     },
 
     'rnaseq_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_rnaseq_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_rnaseq_'.$self->o('release_number'),
       -host   => $self->o('rnaseq_db_server'),
       -port   => $self->o('rnaseq_db_port'),
       -user   => $self->o('user'),
@@ -1033,7 +1032,7 @@ sub default_options {
     },
 
     'rnaseq_blast_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_rnaseq_blast_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_rnaseq_blast_'.$self->o('release_number'),
       -host   => $self->o('rnaseq_blast_db_server'),
       -port   => $self->o('rnaseq_blast_db_port'),
       -user   => $self->o('user'),
@@ -1042,7 +1041,7 @@ sub default_options {
     },
 
     'rnaseq_refine_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_refine_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_refine_'.$self->o('release_number'),
       -host   => $self->o('rnaseq_refine_db_server'),
       -port   => $self->o('rnaseq_refine_db_port'),
       -user   => $self->o('user'),
@@ -1051,7 +1050,7 @@ sub default_options {
     },
 
     'rnaseq_rough_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_rough_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_rough_'.$self->o('release_number'),
       -host   => $self->o('rnaseq_rough_db_server'),
       -port   => $self->o('rnaseq_rough_db_port'),
       -user   => $self->o('user'),
@@ -1064,12 +1063,12 @@ sub default_options {
       -port   => $self->o('lincrna_db_port'),
       -user   => $self->o('user'),
       -pass   => $self->o('password'),
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_lincrna_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_lincrna_'.$self->o('release_number'),
       -driver => $self->o('hive_driver'),
     },
 
     'layering_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_layer_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_layer_'.$self->o('release_number'),
       -host   => $self->o('layering_db_server'),
       -port   => $self->o('layering_db_port'),
       -user   => $self->o('user'),
@@ -1078,7 +1077,7 @@ sub default_options {
     },
 
     'utr_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_utr_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_utr_'.$self->o('release_number'),
       -host   => $self->o('utr_db_server'),
       -port   => $self->o('utr_db_port'),
       -user   => $self->o('user'),
@@ -1087,7 +1086,7 @@ sub default_options {
     },
 
     'genebuilder_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_gbuild_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_gbuild_'.$self->o('release_number'),
       -host   => $self->o('genebuilder_db_server'),
       -port   => $self->o('genebuilder_db_port'),
       -user   => $self->o('user'),
@@ -1096,7 +1095,7 @@ sub default_options {
     },
 
     'pseudogene_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_pseudo_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_pseudo_'.$self->o('release_number'),
       -host   => $self->o('pseudogene_db_server'),
       -port   => $self->o('pseudogene_db_port'),
       -user   => $self->o('user'),
@@ -1114,7 +1113,7 @@ sub default_options {
     },
 
     'final_geneset_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_final_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_final_'.$self->o('release_number'),
       -host   => $self->o('final_geneset_db_server'),
       -port   => $self->o('final_geneset_db_port'),
       -user   => $self->o('user'),
@@ -1123,7 +1122,7 @@ sub default_options {
     },
 
     'refseq_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_refseq_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_refseq_'.$self->o('release_number'),
       -host   => $self->o('refseq_db_server'),
       -port   => $self->o('refseq_db_port'),
       -user   => $self->o('user'),
@@ -1159,7 +1158,7 @@ sub default_options {
     },
 
     'otherfeatures_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').$self->o('production_name_modifier').'_otherfeatures_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_otherfeatures_'.$self->o('release_number'),
       -host   => $self->o('otherfeatures_db_server'),
       -port   => $self->o('otherfeatures_db_port'),
       -user   => $self->o('user'),
@@ -1574,12 +1573,12 @@ sub pipeline_analyses {
               '(1, "assembly.provider_url", "'.$self->o('assembly_provider_url').'"),'.
               '(1, "annotation.provider_name", "'.$self->o('annotation_provider_name').'"),'.
               '(1, "annotation.provider_url", "'.$self->o('annotation_provider_url').'"),'.
-              '(1, "species.production_name", "'.$self->o('production_name').$self->o('production_name_modifier').'"),'.
+              '(1, "species.production_name", "'.$self->o('production_name').'"),'.
               '(1, "repeat.analysis", "'.$self->o('full_repbase_logic_name').'"),'.
               ($self->o('use_repeatmodeler_to_mask') ? '(1, "repeat.analysis", "'.$self->o('repeatmodeler_logic_name').'"),': '').
               '(1, "repeat.analysis", "dust"),'.
               '(1, "repeat.analysis", "trf"),'.
-              '(1, "species.strain_group", "'.$self->o('production_name').'")',
+              '(1, "species.strain_group", "'.$self->o('species_name').'")',
           ],
         },
         -rc_name    => 'default',
@@ -1714,7 +1713,7 @@ sub pipeline_analyses {
             'annotation.provider_name' => $self->o('annotation_provider_name'),
             'annotation.provider_url' => $self->o('annotation_provider_url'),
             'repeat.analysis' => [$self->o('full_repbase_logic_name'), 'dust', 'trf'],
-            'species.production_name' => $self->o('production_name').$self->o('production_name_modifier'),
+            'species.production_name' => $self->o('production_name'),
             'species.taxonomy_id' => $self->o('taxon_id'),
           }
         },

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -8301,7 +8301,7 @@ sub pipeline_analyses {
         -logic_name => 'populate_analysis_descriptions',
         -module     => 'Bio::EnsEMBL::Production::Pipeline::ProductionDBSync::PopulateAnalysisDescription',
         -parameters => {
-                        species => $self->o('species_name'),
+                        species => $self->o('production_name'),
                         group => 'core',
                        },
         -rc_name    => 'default_registry',

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
@@ -252,15 +252,16 @@ sub run {
         $self->param('common_name', $1) if ($common_name =~ /\(([^)]+)\)/);
         $common_name =~ s/\s+\(.+//;
         $self->param('scientific_name', $common_name);
-        # if the common name is not appropriate for web use (i.e. in 'bad_common_names' file) then use the scientific name
-	open(BADNAMES, $self->param('bad_common_name_file')) or $self->throw("Could not open file ".$self->param('bad_common_name_file'));
-        my $check_name = $self->param('common_name');
-        chomp $check_name;
-        while (<BADNAMES>){
-          if (/$check_name/){
-	    $self->param('common_name', lc($self->param('scientific_name')));
-          }
-	}
+### here is code to set the common name to the scientific name if the ncbi common name is too genric, e.g. "birds"
+### This should not be needed
+#	open(BADNAMES, $self->param('bad_common_name_file')) or $self->throw("Could not open file ".$self->param('bad_common_name_file'));
+#        my $check_name = $self->param('common_name');
+#        chomp $check_name;
+#        while (<BADNAMES>){
+#          if (/$check_name/){
+#	    $self->param('common_name', lc($self->param('scientific_name')));
+#          }
+#	}
       }
       elsif ($1 eq 'Infraspecific name') {
         $strain = $2;
@@ -552,7 +553,9 @@ sub write_output {
     $meta_adaptor->store_key_value('strain.type', $self->param('strain_type'));
     $display_name .= ' ('.$self->param('strain').')';
   }
+  $display_name .= ' ('.$self->param('assembly_accession').')';
   $meta_adaptor->store_key_value('species.display_name', $display_name);
+
 
 # Not sure it will properly add the new values, hopefully it will and not cause problems
   my $job_params = destringify($self->input_job->input_id);

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
@@ -541,7 +541,7 @@ sub write_output {
   if ($self->param_is_defined('strain')) {
     $meta_adaptor->store_key_value('species.strain', $self->param('strain'));
     $meta_adaptor->store_key_value('strain.type', $self->param('strain_type'));
-    $display_name .= ' ('.$common_name.' - '.$self->param('strain').')';
+    $display_name .= ' ('.$self->param('strain').')';
   }
   else {
     $display_name .= '('.$common_name.')';

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
@@ -253,10 +253,14 @@ sub run {
         $common_name =~ s/\s+\(.+//;
         $self->param('scientific_name', $common_name);
         # if the common name is not appropriate for web use (i.e. in 'bad_common_names' file) then use the scientific name
-	open(BADNAMES, $self->param('bad_common_name_file'));
-        if (grep{/$self->param('common_name')/} <BADNAMES>){
-          $self->param('common_name', lc($self->param('scientific_name')));
-        }
+	open(BADNAMES, $self->param('bad_common_name_file')) or $self->throw("Could not open file ".$self->param('bad_common_name_file'));
+        my $check_name = $self->param('common_name');
+        chomp $check_name;
+        while (<BADNAMES>){
+          if (/$check_name/){
+	    $self->param('common_name', lc($self->param('scientific_name')));
+          }
+	}
       }
       elsif ($1 eq 'Infraspecific name') {
         $strain = $2;

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
@@ -541,7 +541,7 @@ sub write_output {
   if ($self->param_is_defined('strain')) {
     $meta_adaptor->store_key_value('species.strain', $self->param('strain'));
     $meta_adaptor->store_key_value('strain.type', $self->param('strain_type'));
-    $display_name .= ' ('.$self->param('strain').')';
+    $display_name .= ' ('.$common_name.' - '.$self->param('strain').')';
   }
   else {
     $display_name .= '('.$common_name.')';

--- a/scripts/genebuild/bad_common_names.txt
+++ b/scripts/genebuild/bad_common_names.txt
@@ -1,0 +1,3 @@
+birds
+bony fishes
+reptiles

--- a/scripts/genebuild/bad_common_names.txt
+++ b/scripts/genebuild/bad_common_names.txt
@@ -1,3 +1,0 @@
-birds
-bony fishes
-reptiles

--- a/scripts/genebuild/create_annotation_configs.pl
+++ b/scripts/genebuild/create_annotation_configs.pl
@@ -296,7 +296,7 @@ foreach my $accession (@accession_array) {
 
   # Add in the species url by uppercasing the first letter of the species name
   my $species_url = $assembly_hash->{'species_name'};
-  $species_url = ucfirst($species_url);
+  $species_url = ucfirst($species_url).'_'.$accession;
   $assembly_hash->{'species_url'} = $species_url;
 
   # Get repeatmodeler library path if one exists
@@ -387,6 +387,7 @@ sub parse_assembly_report {
   my $refseq_accession;
   my $assembly_level;
   my $wgs_id;
+  my $modifier;
   open($report_file_handle, '>', \$report_file_content) || throw("could not open $report_file_name");
 
   unless($ftp->get($report_file_name, $report_file_handle)) {
@@ -457,10 +458,22 @@ sub parse_assembly_report {
     say "Found no RefSeq accession for this assembly";
   }
 
+# create production name - must be unique, no more than trinomial, and include GCA
+  my $underscore_count = $species_name =~ tr/_//;
+  my $accession_append = lc($accession);
+  $accession_append =~ s/\./v/g;
+  $accession_append =~ s/_//g;
+  if ($underscore_count == 1){
+    $assembly_hash->{'production_name'} = $species_name.'_'.$accession_append;
+  }
+  else {
+    $assembly_hash->{'production_name'} = $species_name.$accession_append;
+  }
+
+  $assembly_hash->{'strain'} = $species_name;
   $assembly_hash->{'assembly_level'} = $assembly_level;
   $assembly_hash->{'wgs_id'} = $wgs_id;
   $assembly_hash->{'species_name'} = $species_name;
-  $assembly_hash->{'production_name'} = $species_name;
   @{$assembly_hash}{keys(%$general_hash)} = values(%$general_hash);
   $assembly_hash->{'output_path'} .= "/".$species_name."/".$accession."/";
 }

--- a/scripts/genebuild/create_annotation_configs.pl
+++ b/scripts/genebuild/create_annotation_configs.pl
@@ -460,15 +460,12 @@ sub parse_assembly_report {
 
 # create production name - must be unique, no more than trinomial, and include GCA
   my $underscore_count = $species_name =~ tr/_//;
+  $species_name =~ /(^[^-]+_[^-]+)_.*/;
+  my $binomial_name = $1;
   my $accession_append = lc($accession);
   $accession_append =~ s/\./v/g;
   $accession_append =~ s/_//g;
-  if ($underscore_count == 1){
-    $assembly_hash->{'production_name'} = $species_name.'_'.$accession_append;
-  }
-  else {
-    $assembly_hash->{'production_name'} = $species_name.$accession_append;
-  }
+  $assembly_hash->{'production_name'} = $binomial_name.'_'.$accession_append;
 
   $assembly_hash->{'strain'} = $species_name;
   $assembly_hash->{'assembly_level'} = $assembly_level;


### PR DESCRIPTION
Update pipeline for changes on Rapid Release. 
Details here: https://docs.google.com/document/d/1SA8PDWAKcnGFhzcdgjiYVieHGX42nCP5QMdJXic8p2U/edit?ts=5f58ff70#heading=h.hbl22t8t9wgl

IMPORTANT: these changes do not suit the Main Release, if handing a database over for the Main Release, follow instructions here: https://www.ebi.ac.uk/seqdb/confluence/display/ENSGBD/Handing+over+a+database+to+the+Main+release

Re: strains/breeds/etc. **species.strain** is loaded automatically if the 'Infraspecific name' field is present in the assembly report - otherwise strain/breed info needs to be added manually. **strain.type** is automatically set to "strain" and should be changed manually where applicable. 

Changes where tested here: mysql://ensadmin:xxxxx@mysql-ens-genebuild-prod-4.ebi.ac.uk:4530/leanne_canis_lupus_gca008641055v3_pipe_000 

See leanne_canis_lupus_gca008641055v3_core_000 @gb2 for example meta table. 