### PR TITLE
Check first line of file starts with '>'

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadUniProtFiles.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadUniProtFiles.pm
@@ -103,7 +103,7 @@ sub run {
       if (index($response->content(), '>') == 0) {
         if (open(my $fh,'>',$filename)) {
           print $fh $response->content();
-          close $fh;
+          close($fh) || $self->throw("Could not close the file '$filename'");
         } else {
           $self->throw("Could not open file $filename\n");
         }

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadUniProtFiles.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadUniProtFiles.pm
@@ -100,11 +100,16 @@ sub run {
     }
 
     if ($response->is_success()) {
-      if (open(my $fh,'>',$filename)) {
-        print $fh $response->content();
-        close $fh;
-      } else {
-        $self->throw("Could not open file $filename\n");
+      if (index($response->content(), '>') == 0) {
+        if (open(my $fh,'>',$filename)) {
+          print $fh $response->content();
+          close $fh;
+        } else {
+          $self->throw("Could not open file $filename\n");
+        }
+      }
+      else {
+        $self->throw("File '$filename' does not start with a fasta header '>' but website said ".$response->status_line);
       }
       
       if ($filename =~ s/\.gz$//) {


### PR DESCRIPTION
It seems that Uniprot can fails but still returns status 200
The code added is here to help debug rather than fix the problem.
By checking that the file has a fasta header we can make sure that
the code will die when html is returned, thus render the file useless