### PR TITLE
Added missing eval error in Utilities.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Tools/Utilities.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Tools/Utilities.pm
@@ -1052,7 +1052,7 @@ sub hrdb_get_dba {
       }
       eval "use $module_name";
       if ($@) {
-        throw("Cannot find module $module_name");
+        throw("Cannot find module $module_name . Error message: ".$@);
       }
     }
     eval {


### PR DESCRIPTION
Especially useful when some repositories like ensembl-orm are missing and it can take a while to find out.