### PR TITLE
create_annotation_config changes

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -134,10 +134,10 @@ sub default_options {
 # Pipe and ref db info
 ########################
 
-    'projection_source_db_name'    => 'homo_sapiens_core_100_38', # This is generally a pre-existing db, like the current human/mouse core for example
+    'projection_source_db_name'    => '', # This is generally a pre-existing db, like the current human/mouse core for example
     'projection_source_db_server'  => 'mysql-ens-mirror-1',
     'projection_source_db_port'    => '4240',
-    'projection_source_production_name' => 'homo_sapiens',
+    'projection_source_production_name' => '',
 
     'compara_db_name'     => 'leanne_ensembl_compara_95',
     'compara_db_server'  => 'mysql-ens-genebuild-prod-5',

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
@@ -544,7 +544,7 @@ sub write_output {
     $display_name .= ' ('.$self->param('strain').')';
   }
   else {
-    $display_name .= '('.$common_name.')';
+    $display_name .= ' ('.$common_name.')';
   }
   $display_name .= ' - '.$self->param('assembly_accession');
   $meta_adaptor->store_key_value('species.display_name', $display_name);

--- a/scripts/genebuild/create_annotation_configs.pl
+++ b/scripts/genebuild/create_annotation_configs.pl
@@ -520,12 +520,16 @@ sub clade_settings {
       'repbase_library'    => 'primates',
       'repbase_logic_name' => 'primates',
       'uniprot_set'        => 'primates_basic',
+      'projection_source_production_name' => 'homo_sapiens',
+      'projection_source_db_name' => current_projection_source_db('homo_sapiens'),
     },
 
     'rodentia' => {
       'repbase_library'    => 'rodents',
       'repbase_logic_name' => 'rodents',
       'uniprot_set'        => 'mammals_basic',
+      'projection_source_production_name' => 'mus_musculus',
+      'projection_source_db_name' => current_projection_source_db('mus_musculus'),
     },
 
     'mammalia' => {
@@ -533,6 +537,8 @@ sub clade_settings {
       'repbase_logic_name' => 'mammals',
       'uniprot_set'        => 'mammals_basic',
       'ig_tr_fasta_file'    => 'multispecies_ig_tr.fa',
+      'projection_source_production_name' => 'homo_sapiens',
+      'projection_source_db_name' => current_projection_source_db('homo_sapiens'),
     },
 
    'marsupials' => {
@@ -540,12 +546,16 @@ sub clade_settings {
       'repbase_logic_name' => 'mammals',
       'uniprot_set'        => 'mammals_basic',
       'ig_tr_fasta_file'    => 'multispecies_ig_tr.fa',
-},
+      'projection_source_production_name' => 'homo_sapiens',
+      'projection_source_db_name' => current_projection_source_db('homo_sapiens'),
+    },
 
     'aves' => {
       'repbase_library'    => 'Birds',
       'repbase_logic_name' => 'aves',
       'uniprot_set'        => 'birds_basic',
+      'projection_source_production_name' => 'homo_sapiens',
+      'projection_source_db_name' => current_projection_source_db('homo_sapiens'),
     },
 
     'reptiles' => {
@@ -554,6 +564,8 @@ sub clade_settings {
       'uniprot_set'        => 'reptiles_basic',
       'masking_timer_long'  => '6h',
       'masking_timer_short' => '3h',
+      'projection_source_production_name' => 'homo_sapiens',
+      'projection_source_db_name' => current_projection_source_db('homo_sapiens'),
     },
 
     'teleostei' => {
@@ -563,6 +575,8 @@ sub clade_settings {
       'ig_tr_fasta_file'    => 'fish_ig_tr.fa',
       'masking_timer_long'  => '6h',
       'masking_timer_short' => '3h',
+      'projection_source_production_name' => 'danio_rerio',
+      'projection_source_db_name' => current_projection_source_db('danio_rerio'),
     },
 
     'distant_vertebrate' => {
@@ -571,6 +585,8 @@ sub clade_settings {
       'uniprot_set'        => 'distant_vertebrate',
       'masking_timer_long'  => '6h',
       'masking_timer_short' => '3h',
+      'projection_source_production_name' => 'homo_sapiens',
+      'projection_source_db_name' => current_projection_source_db('homo_sapiens'),
     },
 
 
@@ -578,36 +594,48 @@ sub clade_settings {
       'repbase_library'    => 'insecta',
       'repbase_logic_name' => 'insects',
       'uniprot_set'        => 'insects_basic',
+      'projection_source_production_name' => 'homo_sapiens',
+      'projection_source_db_name' => current_projection_source_db('homo_sapiens'),
     },
 
     'non_vertebrates' => {
       'repbase_library'    => 'non_vertebrates',
       'repbase_logic_name' => 'non_vertebrates',
       'uniprot_set'        => 'non_vertebrates_basic',
+      'projection_source_production_name' => 'homo_sapiens',
+      'projection_source_db_name' => current_projection_source_db('homo_sapiens'),
     },
 
     'fungi' => {
       'repbase_library'    => 'fungi',
       'repbase_logic_name' => 'fungi',
       'uniprot_set'        => 'fungi_basic',
+      'projection_source_production_name' => 'homo_sapiens',
+      'projection_source_db_name' => current_projection_source_db('homo_sapiens'),
     },
 
     'metazoa' => {
       'repbase_library'    => 'metazoa',
       'repbase_logic_name' => 'metazoa',
       'uniprot_set'        => 'metazoa_basic',
+      'projection_source_production_name' => 'homo_sapiens',
+      'projection_source_db_name' => current_projection_source_db('homo_sapiens'),
     },
 
     'plants'  => {
       'repbase_library'    => 'plants',
       'repbase_logic_name' => 'plants',
       'uniprot_set'        => 'plants_basic',
+      'projection_source_production_name' => 'homo_sapiens',
+      'projection_source_db_name' => current_projection_source_db('homo_sapiens'),
     },
 
     'protists'  => {
       'repbase_library'    => 'protists',
       'repbase_logic_name' => 'protists',
       'uniprot_set'        => 'protists_basic',
+      'projection_source_production_name' => 'homo_sapiens',
+      'projection_source_db_name' => current_projection_source_db('homo_sapiens'),
     },
 
   };
@@ -816,7 +844,7 @@ sub assign_server_info {
 
   my $server_set = $general_hash->{'server_set'};
   if ($server_set) {
-    if (! exists $servers->{server_set}) {
+    if (! exists $servers->{$server_set}) {
       warning("Could not find an associated server set entry in the HiveBaseConfig for ".$server_set.". Will default to set1");
       $server_set = 'set1';
     }
@@ -913,4 +941,31 @@ sub check_compara_release_version {
       last;
     }
   }
+}
+
+=head2 
+
+ Arg [1]    : Species name, e.g. mus_musculus
+ Description: Looks for the most recent core on the mirror server for the given 
+              species - to be used as reference for projection.
+ Returntype : String
+ Exceptions : Warning if no core exists on mirror for given species
+
+=cut
+sub current_projection_source_db{
+  my ($species) = @_;
+  my $current_db;
+
+  my $cmd = 'mysql-ens-mirror-1 -NB -e "show databases like \''.$species.'_core%\';"';
+  my @out= `$cmd`;
+  if(@out){
+    $current_db = $out[2]; #the 3 most recent versions of a core will be available on mirror
+  }
+  else{
+    my $hs_cmd = 'mysql-ens-mirror-1 -NB -e "show databases like \'homo_sapiens_core%\';"';
+    my @hs_out= `$hs_cmd`;
+    $current_db = $hs_out[2];
+    warning("No core database available on mirror for species, "+$species+" - will use latest homo_sapiens core.");
+  }
+  return $current_db;
 }


### PR DESCRIPTION
Added missing $ for server_set. 
Added subroutine to choose most recent core on mirror as the reference db for projection.
Set projection details as homo_sapiens for all clades except rodents (used mus_musculus). 
Updated Genome_annotation_conf to use only projection details from create_annotation_conf script.

Tested - created a rodent pipe (see lastz analyses for changes in parameters):
mysql://ensadmin:xxxxx@mysql-ens-genebuild-prod-7.ebi.ac.uk:4533/leanne_sciurus_vulgaris_gca902686455v2_pipe_xxx 
And non-rodent:
mysql://ensadmin:xxxxx@mysql-ens-genebuild-prod-7.ebi.ac.uk:4533/leanne_callithrix_jacchus_gca011100555v1_pipe_xxx 
