### PR TITLE
Update placeholder sample locations for new DC

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveAddPlaceholderLocation.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveAddPlaceholderLocation.pm
@@ -94,10 +94,9 @@ sub run {
     my @output = (['sample.location_param', $sample_coord],
                   ['sample.location_text', $sample_coord],
                   ['sample.gene_param', $sample_gene->stable_id()],
-                  ['sample.gene_text', 'ensembl_gene'],
+                  ['sample.gene_text', $sample_gene->stable_id()],
                   ['sample.transcript_param', $sample_transcript->stable_id()],
-                  ['sample.transcript_text', 'ensembl_transcript'],
-                  ['sample.search_text', 'ensembl_gene']);
+                  ['sample.transcript_text', $sample_transcript->stable_id()]);
 
     $self->output(\@output);
 

--- a/scripts/genebuild/get_sample_genes.pl
+++ b/scripts/genebuild/get_sample_genes.pl
@@ -179,11 +179,10 @@ elsif ($core_db){
 INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.location_param', '".$sample_coord."');
 INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.location_text', '".$sample_coord."');
 INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.gene_param', '".$sample_gene->stable_id()."');
-INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.gene_text', 'ensembl_gene');
+INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.gene_text', '".$sample_gene->stable_id()."');
 INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.transcript_param', '".$sample_transcript->stable_id()."');
-INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.transcript_text', 'ensembl_transcript');
-INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.search_text', 'glycoprotein');\n"
-}
+INSERT INTO meta (species_id, meta_key, meta_value) VALUES (1, 'sample.transcript_text', '".$sample_transcript->stable_id()."');"
+  }
   else{
     print "No suitable transcripts found for $core_db\n";
   }


### PR DESCRIPTION
**From correspondence with Production team**
To summarise the problem:
When genebuild hand over databases, there are placeholder values for sample.gene_text, sample.transcript_text, and sample.search_text. These present problems when something goes awry in the post-handover assignment of sample data, because they sneak through onto the website, without causing anything to fail, so we don't notice.

A datacheck has been introduced to flag them up, because there are straightforward options other than placeholder text:

sample.search_text is optional, so that doesn't need to be created, and can be deleted from any databases where it is present.

sample.gene_text and sample.transcript_text can be set to the same value as sample.gene_param and sample.transcript_param, respectively. I _think_ it would be ok to not set them, and the *_param values would be used by default, but I'm not 100%, so it seems safest to explicitly set them.

When a new or updated geneset is detected, Production run a pipeline which overwrites these sample values, using comparative data; it was based on the genebuild script, but has deviated from it a bit by now (https://github.com/Ensembl/ensembl-production/blob/release/104/modules/Bio/EnsEMBL/Production/Pipeline/SampleData/GenerateSampleData.pm).

For Rapid Release, we don't run that pipeline, because without a compara we wouldn't get any better examples than the ones that are already there. So, that means that all the current RR species have placeholder values - these don't seem to cause any bugs, but maybe I'm not looking in the right place. In any case, this datacheck will be in force for RR handover too, so those dbs will need to conform in the same way as the main site. If no-one objects, I will update the dbs on st5, to remove sample.search_texts, and set the gene and transcript 'text' to the 'param' values.

**The following plan was enacted**

- Updated databases for e104 - removed the sample.search_text key pair and updated the sample.gene_text and sample.transcript_text to match the sample.gene_param and sample.transcript_param values  
- Updated all databases on RR
- Edited pipeline to not write the sample.search_text key pair and to set the sample.gene_text and sample.transcript_text to match the sample.gene_param and sample.transcript_param values