### PR TITLE
Added support to load MTs and other plastids with more features

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveAssemblyLoading/HiveLoadMitochondrion.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveAssemblyLoading/HiveLoadMitochondrion.pm
@@ -101,7 +101,6 @@ sub run {
              " -gene_type protein_coding".
              " -trna_type Mt_tRNA".
              " -rrna_type Mt_rRNA".
-             " -codon_table 2".
              " -logic_name mt_genbank_import".
              " -source RefSeq".
              " -accession ".$mt_accession.


### PR DESCRIPTION
Added support for different translation tables: removed codon_table parameter. This is now fetched from the relevant CDS feature "transl_table" attribute.
Added support for multi-exon genes (including reverse strand ones).
Skip 'trans_splicing' features (subject to https://github.com/Ensembl/ensembl-io/pull/117 approval).

Chloroplasts like https://www.ncbi.nlm.nih.gov/nuccore/NC_011032.1 can be loaded now.

This script could be renamed to something more generic to reflect it can load more types of plastids.