### PR TITLE
Remove force_drop from Genome config file

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -4193,7 +4193,6 @@ sub pipeline_analyses {
                          source_db => $self->o('genblast_db'),
                          target_db => $self->o('genblast_nr_db'),
                          create_type => 'copy',
-                         force_drop => 1,
                        },
         -rc_name    => 'default',
         -flow_into => {
@@ -6306,7 +6305,6 @@ sub pipeline_analyses {
                          source_db => $self->o('rnaseq_blast_db'),
                          target_db => $self->o('rnaseq_for_layer_db'),
                          create_type => 'copy',
-                         force_drop => 1,
                        },
         -rc_name    => 'default',
         -flow_into => {
@@ -6396,7 +6394,6 @@ sub pipeline_analyses {
                          source_db => $self->o('rnaseq_for_layer_db'),
                          target_db => $self->o('rnaseq_for_layer_nr_db'),
                          create_type => 'copy',
-                         force_drop => 1,
                        },
         -rc_name    => 'default',
         -flow_into => {
@@ -7235,7 +7232,6 @@ sub pipeline_analyses {
                          source_db => $self->o('genblast_db'),
                          target_db => $self->o('genblast_rnaseq_support_nr_db'),
                          create_type => 'copy',
-                         force_drop => 1,
                        },
         -rc_name    => 'default',
         -flow_into => {


### PR DESCRIPTION
force_drop in the HiveCreateDatabases module should only be used
on the command line or through guiHive as it would try to delete
the database before creating it. Having the parameter set in the
config can cause problem as not everyone would be aware of it and
may accidentally delete some precious databases.