### PR TITLE
Add default strain keys for everything - there is a DC blocker for RR

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
@@ -544,6 +544,8 @@ sub write_output {
     $display_name .= ' ('.$self->param('strain').')';
   }
   else {
+    $meta_adaptor->store_key_value('species.strain', 'reference');
+    $meta_adaptor->store_key_value('strain.type', 'strain');
     $display_name .= ' ('.$common_name.')';
   }
   $display_name .= ' - '.$self->param('assembly_accession');


### PR DESCRIPTION
There is a MetaKeyConditional datacheck that requires strain.type and species.strain keys exist in the meta table. As default this will be set as a reference (where the Infraspecific name exists in the assembly report it will be set appropriately). These keys are sufficient for the Rapid Release - no more needs to be done.

For the Main release, if the species belongs to any of the strain/breed sets then and extra strain meta key must be added to ensure that the strain/breeds table is created. See here for details (https://www.ebi.ac.uk/seqdb/confluence/display/ENSGBD/Handing+over+a+database+to+the+Main+release#HandingoveradatabasetotheMainrelease-Metakeys).