### PR TITLE
Set display_xref for refseq transcripts...

### DIFF
--- a/scripts/refseq/parse_ncbi_gff3.pl
+++ b/scripts/refseq/parse_ncbi_gff3.pl
@@ -620,6 +620,9 @@ GENE: foreach my $gene (values %genes) {
         }
       }
       $stats{transcript}->{$transcript->biotype}++;
+      if (!$transcript->display_xref()) {
+        $transcript->display_xref($gene->display_xref());
+      }
     }
     $gene->recalculate_coordinates; #Because I'm adding transcript first, I need to force recalculate
   }


### PR DESCRIPTION
... to the gene display_xref if it has not been set before.
This is to fix the "NCBI transcripts have accession as either stable_id or display_xref" issue.