### PR TITLE
Updated path run_cmsearch to point to correct filtered rfam.cm file

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -127,7 +127,7 @@ sub default_options {
     'rfam_path' => catfile($self->o('base_blast_db_path'), 'ncrna', 'Rfam_14.0'),
     'rfam_seeds' => $self->o('rfam_path') . "/Rfam.seed",
     'rfam_cm' => $self->o('rfam_path') . "/Rfam.cm",
-    'filtered_rfam_cm' => $self->o('output_path') . '/Rfam.cm',
+    'filtered_rfam_cm' => $self->o('output_path') .  'ncrna/Rfam.cm',
     'clade' => $self->o('repbase_logic_name'),
 
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -5146,7 +5146,7 @@ sub pipeline_analyses {
             cmd => "perl " . $self->o('sncrna_analysis_script') . "/filter_cm.pl " .
                              $self->o('rfam_cm') . ' ' .
                              $self->o('ncrna_dir') . '/accessions.txt ' .
-                             $self->o('ncrna_dir') . '/Rfam.cm',
+                             $self->o('filtered_rfam_cm'),
         },
         -rc_name => 'filter',
       },

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -127,7 +127,7 @@ sub default_options {
     'rfam_path' => catfile($self->o('base_blast_db_path'), 'ncrna', 'Rfam_14.0'),
     'rfam_seeds' => $self->o('rfam_path') . "/Rfam.seed",
     'rfam_cm' => $self->o('rfam_path') . "/Rfam.cm",
-    'filtered_rfam_cm' => $self->o('output_path') .  'ncrna/Rfam.cm',
+    'filtered_rfam_cm' => $self->o('ncrna_dir') .  '/Rfam.cm',
     'clade' => $self->o('repbase_logic_name'),
 
 
@@ -5146,7 +5146,7 @@ sub pipeline_analyses {
             cmd => "perl " . $self->o('sncrna_analysis_script') . "/filter_cm.pl " .
                              $self->o('rfam_cm') . ' ' .
                              $self->o('ncrna_dir') . '/accessions.txt ' .
-                             $self->o('ncrna_dir'),
+                             $self->o('ncrna_dir') . '/Rfam.cm',
         },
         -rc_name => 'filter',
       },

--- a/scripts/genebuild/sncrna/filter_cm.pl
+++ b/scripts/genebuild/sncrna/filter_cm.pl
@@ -44,11 +44,11 @@ sub filter_rfam {
 
 my $rfam_cm_file       = $ARGV[0]; #$self->param_required('rfam_cm_file');
 my $rfam_accessions   = $ARGV[1]; #$self->param_required('rfam_accessions');
-my $working_dir        = $ARGV[2]; #$self->param_required("working_dir");
+#my $working_dir        = $ARGV[2]; #$self->param_required("working_dir");
 
 my $cm_path = path($rfam_cm_file);
 my $ra_path = path($rfam_accessions);
-my $output = path($working_dir . "/Rfam.cm");
+my $output = $ARGV[2];#path($working_dir . "/Rfam.cm");
 
 my $cm = $cm_path->slurp;
 my $ra = $ra_path->slurp;

--- a/scripts/genebuild/sncrna/filter_cm.pl
+++ b/scripts/genebuild/sncrna/filter_cm.pl
@@ -44,7 +44,6 @@ sub filter_rfam {
 
 my $rfam_cm_file       = $ARGV[0]; #$self->param_required('rfam_cm_file');
 my $rfam_accessions   = $ARGV[1]; #$self->param_required('rfam_accessions');
-#my $working_dir        = $ARGV[2]; #$self->param_required("working_dir");
 
 my $cm_path = path($rfam_cm_file);
 my $ra_path = path($rfam_accessions);


### PR DESCRIPTION
The path to Rfam.cm was updated to point to the ncrna subdirectory rather than the root assembly directory.
Code has tested on a new pipeline and it worked as needed.