### PR TITLE
Hotfix/biotype sample length

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -8839,29 +8839,8 @@ sub pipeline_analyses {
         -rc_name    => 'default',
 
         -flow_into => {
-                        '1' => ['restore_biotype_source_length_rnaseq_db'],
+                        '1' => ['prepare_rnaseq_meta_data'],
                       },
-      },
-
-      {
-        # The biotype and source lengths were increased to allow for the use of longer transcriptomic data sample names in the refine db
-        # It has to be reversed by the end of the pipeline because the longer biotypes and sources do not end up
-        # in the final rnaseq database
-        -logic_name => 'restore_biotype_source_length_rnaseq_db',
-        -module => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
-        -parameters => {
-          db_conn    => $self->o('rnaseq_db'),
-          sql => [
-	    'ALTER TABLE gene MODIFY biotype varchar(40)',
-	    'ALTER TABLE transcript MODIFY biotype varchar(40)',
-	    'ALTER TABLE gene MODIFY source varchar(40)',
-	    'ALTER TABLE transcript MODIFY source varchar(40)'
-          ],
-        },
-        -rc_name    => 'default',
-        -flow_into => {
-          1 => ['prepare_rnaseq_meta_data'],
-        },
       },
 
       {
@@ -8893,10 +8872,30 @@ sub pipeline_analyses {
         -rc_name    => 'default',
 
         -flow_into => {
-                        '1' => ['generate_rnaseq_stable_ids'],
+                        '1' => ['restore_biotype_source_length_rnaseq_db'],
                       },
       },
 
+      {
+        # The biotype and source lengths were increased to allow for the use of longer transcriptomic data sample names in the refine db
+        # It has to be reversed by the end of the pipeline because the longer biotypes and sources do not end up
+        # in the final rnaseq database
+        -logic_name => 'restore_biotype_source_length_rnaseq_db',
+        -module => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+        -parameters => {
+          db_conn    => $self->o('rnaseq_db'),
+          sql => [
+	    'ALTER TABLE gene MODIFY biotype varchar(40)',
+	    'ALTER TABLE transcript MODIFY biotype varchar(40)',
+	    'ALTER TABLE gene MODIFY source varchar(40)',
+	    'ALTER TABLE transcript MODIFY source varchar(40)'
+          ],
+        },
+        -rc_name    => 'default',
+        -flow_into => {
+          1 => ['generate_rnaseq_stable_ids'],
+        },
+      },
 
       {
         -logic_name => 'generate_rnaseq_stable_ids',

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -1464,7 +1464,7 @@ sub pipeline_analyses {
                        },
         -rc_name    => 'default',
         -flow_into  => {
-                         1 => ['increase_biotype_length'],
+                         1 => ['increase_biotype_source_length'],
                        },
       },
 
@@ -1472,13 +1472,15 @@ sub pipeline_analyses {
         # This will allow for the use of longer transcriptomic data sample names in the refine db
         # It will be reversed by the end of the pipeline because the longer biotypes do not end up
         # in the final core database
-        -logic_name => 'increase_biotype_length',
+        -logic_name => 'increase_biotype_source_length',
         -module => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
         -parameters => {
           db_conn    => $self->o('reference_db'),
           sql => [
 	    'ALTER TABLE gene MODIFY biotype varchar(128)',
-	    'ALTER TABLE transcript MODIFY biotype varchar(128)'
+	    'ALTER TABLE transcript MODIFY biotype varchar(128)',
+	    'ALTER TABLE gene MODIFY source varchar(128)',
+	    'ALTER TABLE transcript MODIFY source varchar(128)'
           ],
         },
         -rc_name    => 'default',
@@ -8306,7 +8308,7 @@ sub pipeline_analyses {
         -max_retry_count => 0,
         -rc_name => '8GB',
         -flow_into => {
-                        1 => ['restore_biotype_length'],
+                        1 => ['restore_biotype_source_length'],
                       },
       },
 
@@ -8314,13 +8316,15 @@ sub pipeline_analyses {
         # The biotype length was increased to allow for the use of longer transcriptomic data sample names in the refine db
         # It has to be reversed by the end of the pipeline because the longer biotypes do not end up
         # in the final core database
-        -logic_name => 'restore_biotype_length',
+        -logic_name => 'restore_biotype_source_length',
         -module => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
         -parameters => {
           db_conn    => $self->o('reference_db'),
           sql => [
 	    'ALTER TABLE gene MODIFY biotype varchar(40)',
-	    'ALTER TABLE transcript MODIFY biotype varchar(40)'
+	    'ALTER TABLE transcript MODIFY biotype varchar(40)',
+	    'ALTER TABLE gene MODIFY source varchar(40)',
+	    'ALTER TABLE transcript MODIFY source varchar(40)'
           ],
         },
         -rc_name    => 'default',

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -8308,15 +8308,15 @@ sub pipeline_analyses {
         -max_retry_count => 0,
         -rc_name => '8GB',
         -flow_into => {
-                        1 => ['restore_biotype_source_length'],
+                        1 => ['restore_biotype_source_length_core_db'],
                       },
       },
 
       {
-        # The biotype length was increased to allow for the use of longer transcriptomic data sample names in the refine db
-        # It has to be reversed by the end of the pipeline because the longer biotypes do not end up
+        # The biotype and source lengths were increased to allow for the use of longer transcriptomic data sample names in the refine db
+        # It has to be reversed by the end of the pipeline because the longer biotypes and sources do not end up
         # in the final core database
-        -logic_name => 'restore_biotype_source_length',
+        -logic_name => 'restore_biotype_source_length_core_db',
         -module => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
         -parameters => {
           db_conn    => $self->o('reference_db'),
@@ -8525,11 +8525,30 @@ sub pipeline_analyses {
                        },
         -rc_name    => 'default',
         -flow_into  => {
-                         1 => ['update_cdna_analyses'],
+                         1 => ['restore_biotype_source_length_otherfeatures_db'],
                        },
       },
 
-
+      {
+        # The biotype and source lengths were increased to allow for the use of longer transcriptomic data sample names in the refine db
+        # It has to be reversed by the end of the pipeline because the longer biotypes and sources do not end up
+        # in the final otherfeatures database
+        -logic_name => 'restore_biotype_source_length_otherfeatures_db',
+        -module => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+        -parameters => {
+          db_conn    => $self->o('otherfeatures_db'),
+          sql => [
+	    'ALTER TABLE gene MODIFY biotype varchar(40)',
+	    'ALTER TABLE transcript MODIFY biotype varchar(40)',
+	    'ALTER TABLE gene MODIFY source varchar(40)',
+	    'ALTER TABLE transcript MODIFY source varchar(40)'
+          ],
+        },
+        -rc_name    => 'default',
+        -flow_into => {
+          1 => ['update_cdna_analyses'],
+        },
+      },
 
       {
         -logic_name => 'update_cdna_analyses',
@@ -8820,10 +8839,30 @@ sub pipeline_analyses {
         -rc_name    => 'default',
 
         -flow_into => {
-                        '1' => ['prepare_rnaseq_meta_data'],
+                        '1' => ['restore_biotype_source_length_rnaseq_db'],
                       },
       },
 
+      {
+        # The biotype and source lengths were increased to allow for the use of longer transcriptomic data sample names in the refine db
+        # It has to be reversed by the end of the pipeline because the longer biotypes and sources do not end up
+        # in the final rnaseq database
+        -logic_name => 'restore_biotype_source_length_rnaseq_db',
+        -module => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+        -parameters => {
+          db_conn    => $self->o('rnaseq_db'),
+          sql => [
+	    'ALTER TABLE gene MODIFY biotype varchar(40)',
+	    'ALTER TABLE transcript MODIFY biotype varchar(40)',
+	    'ALTER TABLE gene MODIFY source varchar(40)',
+	    'ALTER TABLE transcript MODIFY source varchar(40)'
+          ],
+        },
+        -rc_name    => 'default',
+        -flow_into => {
+          1 => ['prepare_rnaseq_meta_data'],
+        },
+      },
 
       {
         -logic_name => 'prepare_rnaseq_meta_data',

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -1194,6 +1194,9 @@ sub pipeline_create_commands {
         elsif ($key eq 'DS') {
             $tables .= $key.' VARCHAR(255) NOT NULL,'
         }
+	elsif ($key eq 'SM') {
+            $tables .= $key.' VARCHAR(138) NOT NULL,'
+        }
         else {
             $tables .= $key.' VARCHAR(50) NOT NULL,'
         }
@@ -1461,10 +1464,28 @@ sub pipeline_analyses {
                        },
         -rc_name    => 'default',
         -flow_into  => {
-                         1 => ['populate_production_tables'],
+                         1 => ['increase_biotype_length'],
                        },
       },
 
+      {
+        # This will allow for the use of longer transcriptomic data sample names in the refine db
+        # It will be reversed by the end of the pipeline because the longer biotypes do not end up
+        # in the final core database
+        -logic_name => 'increase_biotype_length',
+        -module => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+        -parameters => {
+          db_conn    => $self->o('reference_db'),
+          sql => [
+	    'ALTER TABLE gene MODIFY biotype varchar(128)',
+	    'ALTER TABLE transcript MODIFY biotype varchar(128)'
+          ],
+        },
+        -rc_name    => 'default',
+        -flow_into => {
+          1 => ['populate_production_tables'],
+        },
+      },
 
       {
         # Load production tables into each reference
@@ -8285,8 +8306,27 @@ sub pipeline_analyses {
         -max_retry_count => 0,
         -rc_name => '8GB',
         -flow_into => {
-                        1 => ['update_ISE'],
+                        1 => ['restore_biotype_length'],
                       },
+      },
+
+      {
+        # The biotype length was increased to allow for the use of longer transcriptomic data sample names in the refine db
+        # It has to be reversed by the end of the pipeline because the longer biotypes do not end up
+        # in the final core database
+        -logic_name => 'restore_biotype_length',
+        -module => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+        -parameters => {
+          db_conn    => $self->o('reference_db'),
+          sql => [
+	    'ALTER TABLE gene MODIFY biotype varchar(40)',
+	    'ALTER TABLE transcript MODIFY biotype varchar(40)'
+          ],
+        },
+        -rc_name    => 'default',
+        -flow_into => {
+          1 => ['update_ISE'],
+        },
       },
 
      {

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadCsvENA.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadCsvENA.pm
@@ -288,8 +288,13 @@ sub run {
                         $line{age} .= ' '.$data->{characteristics}->{age}->[0]->{unit};
                       }
                     }
-                    if (exists $data->{characteristics}->{tissue}) {
-                      $line{organismPart} = $data->{characteristics}->{tissue}->[0]->{text};
+                    if (exists $data->{characteristics}->{tissue} ||
+                        exists $data->{characteristics}->{'tissue type'} ||
+                        exists $data->{characteristics}->{tissue_type}
+                       ) {
+                      $line{organismPart} = $data->{characteristics}->{tissue}->[0]->{text} ||
+                                            $data->{characteristics}->{'tissue type'}->[0]->{text} ||
+                                            $data->{characteristics}->{tissue_type}->[0]->{text}  ;
                       if (exists $data->{characteristics}->{tissue}->[0]->{ontologyTerms}) {
                         $line{uberon} = $data->{characteristics}->{tissue}->[0]->{ontologyTerms}->[-1];
                       }
@@ -354,6 +359,11 @@ sub run {
 
           if ($samples{$sample}->{sex}) {
             $samples{$sample}->{sample_name} = $samples{$sample}->{sex}.'_'.$samples{$sample}->{sample_name};
+          }
+
+          if ($samples{$sample}->{cellType} || $samples{$sample}->{organismPart} || $samples{$sample}->{sample_alias} || $samples{$sample}->{description}) {
+            $samples{$sample}->{sample_name} .= '_';
+            $samples{$sample}->{sample_name} .= $samples{$sample}->{cellType} || $samples{$sample}->{organismPart} || $samples{$sample}->{sample_alias} || $samples{$sample}->{description};
           }
         }
       }

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveGenerateRefineConfig.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveGenerateRefineConfig.pm
@@ -170,7 +170,7 @@ sub fetch_input {
   my $analysis_adaptor = $self->get_database_by_name('target_db')->get_AnalysisAdaptor;
   my $table_info_sth = $analysis_adaptor->dbc->db_handle->column_info(undef, $analysis_adaptor->dbc->dbname, 'gene', 'source');
   my $source_size = 40;
-  my $biotype_size = 40;
+  my $biotype_size = 128;
   if ($table_info_sth) {
     my $column = $table_info_sth->fetchall_arrayref;
     if (@$column) {
@@ -197,7 +197,7 @@ sub fetch_input {
         next unless ($analysis_adaptor->fetch_by_logic_name($base_logic_name."_$gene_suffix"));
         my $best_key = "best_$key";
         if (length($best_key) > $biotype_size) {
-          $best_key = substr($best_key, 0, 40);
+          $best_key = substr($best_key, 0, $biotype_size);
         }
         if (exists $string_size_check{$best_key}) {
           $self->throw("You should check your sample names, best_$key was too long but $best_key already exists");
@@ -207,7 +207,7 @@ sub fetch_input {
         }
         my $single_key = "single_$key";
         if (length($single_key) > $biotype_size) {
-          $single_key = substr($single_key, 0, 40);
+          $single_key = substr($single_key, 0, $biotype_size);
         }
         if (exists $string_size_check{$single_key}) {
           $self->throw("You should check your sample names, single_$key was too long but $single_key already exists");
@@ -218,9 +218,9 @@ sub fetch_input {
         my %analysis_hash = (BEST_SCORE => $best_key, SINGLE_EXON_MODEL => $single_key, INTRON_OVERLAP_THRESHOLD => $default_iot);
         if ($self->param_is_defined('other_isoforms')) {
           my $other_isoforms = $self->param('other_isoforms').'_'.$key;
-          $analysis_hash{OTHER_ISOFORMS} = length($other_isoforms) > $biotype_size ? substr($other_isoforms, 0, 40) : $other_isoforms;
+          $analysis_hash{OTHER_ISOFORMS} = length($other_isoforms) > $biotype_size ? substr($other_isoforms, 0, $biotype_size) : $other_isoforms;
           if (exists $string_size_check{$other_isoforms}) {
-            $self->throw("You should check your sample names, $other_isoforms was too long but ".substr($other_isoforms, 0, 40).' already exists');
+            $self->throw("You should check your sample names, $other_isoforms was too long but ".substr($other_isoforms, 0, $biotype_size).' already exists');
           }
           else {
             $string_size_check{$other_isoforms} = 1;
@@ -228,9 +228,9 @@ sub fetch_input {
         }
         if ($self->param_is_defined('bad_models')) {
           my $bad_models = $self->param('bad_models').'_'.$key;
-          $analysis_hash{BAD_MODELS} = length($bad_models) > $biotype_size ? substr($bad_models, 0, 40) : $bad_models;
+          $analysis_hash{BAD_MODELS} = length($bad_models) > $biotype_size ? substr($bad_models, 0, $biotype_size) : $bad_models;
           if (exists $string_size_check{$bad_models}) {
-            $self->throw("You should check your sample names, $bad_models was too long but ".substr($bad_models, 0, 40).' already exists');
+            $self->throw("You should check your sample names, $bad_models was too long but ".substr($bad_models, 0, $biotype_size).' already exists');
           }
           else {
             $string_size_check{$bad_models} = 1;

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveParseCsvIntoTable.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveParseCsvIntoTable.pm
@@ -27,7 +27,7 @@ use parent ('Bio::EnsEMBL::Hive::RunnableDB::JobFactory');
 
  Arg [1]    : None
  Description: Defaults parameters for the module
-               _sample_column_size => 50, #Trying to detect using DBI otherwise it should be set to the value of the 'sample_name' column to be effective
+               _sample_column_size => 138, #Trying to detect using DBI otherwise it should be set to the value of the 'sample_name' column to be effective
  Returntype : Hashref
  Exceptions : None
 
@@ -38,7 +38,7 @@ sub param_defaults {
 
   return {
     %{$self->SUPER::param_defaults},
-    _sample_column_size => 50,
+    _sample_column_size => 138,
   }
 }
 


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
Fix
_Include a short description_
It will allow to use longer sample names for rnaseq data in the analysis logic_name column. Previously they would have been truncated because the biotype and source columns have a much shorter length limit compared to logic name and the former are used in production mode before being stored in logic name at the end of the process.
_Include links to JIRA tickets_
N/A
# Testing
_Have you tested it?_
Yes, on sheep gca016772045v1
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
