### PR TITLE
Do not store synonyms if they are 'na' in HiveProcessAssemblyReport.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessAssemblyReport.pm
@@ -312,7 +312,9 @@ sub run {
         $slice->{karyotype_rank} = $karyotype_attribute if ($karyotype_attribute);
         $slice->{_gb_insdc_name} = $data[4];
         if ($data[4] eq $seq_region_name) {
-          push(@{$slice->{add_synonym}}, [$data[0], undef]);
+          if ($data[0] ne 'na') {
+            push(@{$slice->{add_synonym}}, [$data[0], undef]);
+          }
         }
         else {
           push(@{$slice->{add_synonym}}, [$data[4], $synonym_id->{INSDC}]);


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
Fix.
_Include a short description_
Do not store synonyms if they are 'na'.
_Include links to JIRA tickets_
https://www.ebi.ac.uk/panda/jira/browse/ENSGENEBUI-234
# Testing
_Have you tested it?_
Yes. On marmota_monax_gca901343595v1, ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/901/343/595/GCA_901343595.1_MONAX5/GCA_901343595.1_MONAX5_assembly_report.txt
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
