### PR TITLE
Raise warning if no sequence found for uniprot download pe12 or pe3

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadUniProtFiles.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDownloadUniProtFiles.pm
@@ -108,8 +108,10 @@ sub run {
           $self->throw("Could not open file $filename\n");
         }
       }
-      else {
-        $self->throw("File '$filename' does not start with a fasta header '>' but website said ".$response->status_line);
+      elsif ($response->content() eq ""){
+        $self->warning("File '$filename' contains no sequence");
+      }
+      else{
       }
       
       if ($filename =~ s/\.gz$//) {


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
A fix
_Include a short description_
Raise warning and stop pipeline from failing if no uniprot sequence is found at existence level 1 or 2 or 3
_Include links to JIRA tickets_
https://www.ebi.ac.uk/panda/jira/projects/ENSGENEBUI/issues/ENSGENEBUI-525?filter=allopenissues&orderby=assignee+ASC%2C+priority+DESC%2C+updated+DESC
# Testing
_Have you tested it?_
Yes. Used taxon id 52653, 72105 and 10068
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
Jamie