### PR TITLE
Adding extra checks to genebuild status during pipeline initialisation

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/DBSQL/AssemblyRegistryAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/DBSQL/AssemblyRegistryAdaptor.pm
@@ -394,6 +394,28 @@ sub fetch_clade_by_taxon_id {
 
 =head1 Description of method
 
+This method returns the status of an annotation via its assembly_accession.
+
+=cut
+
+sub fetch_genebuild_status_by_gca {
+  my ($self,$chain_version,$type) = @_;
+
+  my $sql = "SELECT progress_status,date_started,date_completed,genebuilder FROM genebuild_status WHERE assembly_accession=? and is_current = ?";
+  my $sth = $self->dbc->prepare($sql);
+  $sth->bind_param(1,$chain_version);
+  $sth->bind_param(2,1);
+  $sth->execute();
+
+  my @genebuild_status = $sth->fetchrow_array();
+  return(@genebuild_status);
+}
+
+
+=pod
+
+=head1 Description of method
+
 This method takes an accession and returns the chain and versionn of the assembly.
 
 =cut


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
Update
_Include a short description_
During Genebuild initialisation, it is needed to check the status of an assembly, i.e, if someone else has already begun its annotation and/or whether it has been completed. Depending on the response, the pipeline can proceed with initialisation or not.
_Include links to JIRA tickets_
https://www.ebi.ac.uk/panda/jira/browse/ENSGENEBUI-508
# Testing
_Have you tested it?_
Yes
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
