### PR TITLE
updated HiveHealthcheck module to reflect the correct species url on …

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveHealthcheck.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveHealthcheck.pm
@@ -216,9 +216,8 @@ sub meta_table {
     if (@$meta_results == 1) {
       $species_url = $meta_results->[0];
       if ($species_production_name) {
-        $species_production_name =~ s/^(\w)/\U$1/;
-        $species_production_name =~ s/(gca)/GCA_/m;
-        $species_production_name =~ s/(?=v\d+)\D+/./gi;
+        $species_production_name =~ s/^(\w)/\U$1\E/;
+        $species_production_name =~ s/gca(\d+)v(\d+)$/GCA_$1.$2/;
         $self->say_with_header("$species_production_name and $species_url are different, one of them could be wrong")
           unless ($species_production_name eq $species_url);
       }
@@ -561,11 +560,9 @@ sub rnaseq_analysis_sanity {
   my $failed = 1;
   my $total = 0;
   my $lc_count = 0;
-  my @analysis_name;
   foreach my $analysis (@{$analysis_adaptor->fetch_all}) {
     ++$total;
     my $ln = $analysis->logic_name;
-    $analysis_name[$total-1]=$analysis->logic_name;
     if ($ln eq 'other_protein') {
       $failed = 0;
     }
@@ -599,7 +596,6 @@ sub rnaseq_analysis_sanity {
       $self->say_with_header('There is a problem with your analysis '.$base);
       $self->say_with_header('Check if gene, daf, bam and ise analyses are present.');
       $self->say_with_header('Total number of analyses in the database: '.$total);
-      $self->say_with_header('List of analyses present in the database: '.join("\n",@analysis_name), "\n");
     }
   }
   if ($failed) {

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveHealthcheck.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveHealthcheck.pm
@@ -216,7 +216,9 @@ sub meta_table {
     if (@$meta_results == 1) {
       $species_url = $meta_results->[0];
       if ($species_production_name) {
-        $species_production_name =~ s/^(\w)/\U$1\E/;
+        $species_production_name =~ s/^(\w)/\U$1/;
+        $species_production_name =~ s/(gca)/GCA_/m;
+        $species_production_name =~ s/(?=v\d+)\D+/./gi;
         $self->say_with_header("$species_production_name and $species_url are different, one of them could be wrong")
           unless ($species_production_name eq $species_url);
       }

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveHealthcheck.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveHealthcheck.pm
@@ -561,9 +561,11 @@ sub rnaseq_analysis_sanity {
   my $failed = 1;
   my $total = 0;
   my $lc_count = 0;
+  my @analysis_name;
   foreach my $analysis (@{$analysis_adaptor->fetch_all}) {
     ++$total;
     my $ln = $analysis->logic_name;
+    $analysis_name[$total-1]=$analysis->logic_name;
     if ($ln eq 'other_protein') {
       $failed = 0;
     }
@@ -595,6 +597,9 @@ sub rnaseq_analysis_sanity {
     if ($bases{$base} != 4) {
       $failed = 1;
       $self->say_with_header('There is a problem with your analysis '.$base);
+      $self->say_with_header('Check if gene, daf, bam and ise analyses are present.');
+      $self->say_with_header('Total number of analyses in the database: '.$total);
+      $self->say_with_header('List of analyses present in the database: '.join("\n",@analysis_name), "\n");
     }
   }
   if ($failed) {


### PR DESCRIPTION
…species production name

# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
Fix
_Include a short description_
In the Healthcheck pipeline it is needed to check that the species name url reflects the production name. The species name is modified thanks to a regex especially in order to write the GCA version with dot as in the production name. The regex has been updated to allow matching between the production name and the species url.
Moreover the error message on the report "there is a problem with your analysis" has been updated
_Include links to JIRA tickets_
https://www.ebi.ac.uk/panda/jira/browse/ENSGENEBUI-550
# Testing
_Have you tested it?_
Yes
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
