### PR TITLE
Skip missing uniprot files to avoid pipeline failure

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveGenerateBestTargettedIndex.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveGenerateBestTargettedIndex.pm
@@ -252,6 +252,10 @@ sub write_output {
   }
   if ($self->param_is_defined('protein_files')) {
     foreach my $file (@{$self->param('protein_files')}) {
+      unless(-e $file){
+        $self->warning("File does not exist. Missing file path is $file");
+        next;
+      }
       my $protein_file = Bio::SeqIO->new(-format => 'fasta', -file => $file);
       while (my $seq = $protein_file->next_seq) {
         my $id = $seq->id;

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessUniProtFiles.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveProcessUniProtFiles.pm
@@ -94,8 +94,10 @@ sub fetch_input {
     open(FH, '>'.$self->param('output_file')) || $self->throw('Could not open '.$self->param('output_file'));
   }
   foreach my $file_path (@$files) {
-    $self->throw("The input id doesn't exist, offending path:\n$file_path")
-      unless(-e $file_path);
+    unless(-e $file_path){
+      $self->warning("The input id doesn't exist, offending path:\n$file_path");
+      next;
+    }
     my (undef, undef, $group_name) = splitpath($file_path);
     $group_name =~ s/\.\w+$//;
 


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
Yes
_Include a short description_
In a previous PR, we had implemented the option not to break the pipeline for species with missing Uniprot files during download. Because these files are needed in other downstream analysis, there is the need to as well skip those same files to avoid further pipeline failures. 
_Include links to JIRA tickets_

# Testing
_Have you tested it?_
Yes
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
William