### PR TITLE
Remove transcripts without translation in HiveCleanGeneset

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveCleanGeneset.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveCleanGeneset.pm
@@ -646,18 +646,21 @@ sub check_protein_models {
     }
   }
 
-  my $supporting_feature = shift(@$supporting_features);
-  my $coverage = $supporting_feature->hcoverage;
-  my $translation = $transcript->translation->seq;
-  my $hit_name = $supporting_feature->hseqname;
-  if($coverage < 75 && $translation !~ /^M/) {
-    say "Removing transcript ".$transcript->seq_region_name.":".$transcript->seq_region_start.":".$transcript->seq_region_end.":".$hit_name.":".$coverage;
-    say "Translation:\n".$translation;
+  if (!($transcript->translation())) {
+    say "Removing transcript because it has no translation ".$transcript->seq_region_name.":".$transcript->seq_region_start.":".$transcript->seq_region_end;
     return(1);
+  } else {
+    my $supporting_feature = shift(@$supporting_features);
+    my $coverage = $supporting_feature->hcoverage;
+    my $translation = $transcript->translation->seq;
+    my $hit_name = $supporting_feature->hseqname;
+    if($coverage < 75 && $translation !~ /^M/) {
+      say "Removing transcript ".$transcript->seq_region_name.":".$transcript->seq_region_start.":".$transcript->seq_region_end.":".$hit_name.":".$coverage;
+      say "Translation:\n".$translation;
+      return(1);
+    }
+    return(0);
   }
-
-  return(0);
-
 }
 
 1;


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
Fix.
_Include a short description_
In some cases there could be transcripts that don't have translation and end up in a loop where it's assumed they have translation. Added check for translation and remove those which do not have it instead of throwing an exception when trying to call on an undefined value (undefined translation).
_Include links to JIRA tickets_
N/A.
# Testing
_Have you tested it?_
Yes, on salmon.
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
