### PR TITLE
Update HiveParseCsvIntoTable.pm fix DS issue

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveParseCsvIntoTable.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveParseCsvIntoTable.pm
@@ -125,6 +125,9 @@ sub write_output {
           $input_id->{$key} =~ tr /:\t/ /;
         }
 
+        my ($project_id_cvs,$sample_id_csv,$rest_of_DS) = split(',', $input_id->{DS}, 3);
+        $input_id->{DS} = $project_id_cvs . "-" . $sample_id_csv;
+
         my $table_adaptor = $self->db->get_NakedTableAdaptor;
         $table_adaptor->table_name($self->param('csvfile_table'));
         $table_adaptor->store([$input_id]);


### PR DESCRIPTION
Update HiveParseCsvIntoTable.pm to fix long DS issue. If Description is very long, it will take only the first 2 elements (project and sample ids).

# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
This is a fix

_Include a short description_
Update HiveParseCsvIntoTable.pm to fix long DS issue. If Description is very long, it will take only the first 2 elements (project and sample ids).

_Include links to JIRA tickets_
No. There was a meeting discussion.

# Testing
_Have you tested it?_
Not the whole fix. 

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
@thibauthourlier 
