### PR TITLE
Update add_rnaseq_analysis_descriptions.pl

### DIFF
--- a/scripts/genebuild/add_rnaseq_analysis_descriptions.pl
+++ b/scripts/genebuild/add_rnaseq_analysis_descriptions.pl
@@ -161,14 +161,14 @@ sub get_values {
 
   my %description = (
 		     'rnaseq_gene' => "Annotation generated from ".$sample_name." RNA-seq data",
-		     'rnaseq_bam'  => 'BWA alignments of '.$sample_name.' RNA-seq data. This BAM file can be downloaded from the <a href=\\"ftp://ftp.ensembl.org/pub/data_files/\\">Ensembl FTP site</a>',
+		     'rnaseq_bam'  => 'Alignments of '.$sample_name.' RNA-seq data. This BAM file can be downloaded from the <a href=\\"ftp://ftp.ensembl.org/pub/data_files/\\">Ensembl FTP site</a>',
 		     'rnaseq_ise'  => "Spliced-read support for ".$sample_name,
 		     'rnaseq_daf'  => "Spliced-read support for ".$sample_name,
 		    );
 
   my %display_label = (
          	     'rnaseq_gene' => $sample_name." RNA-seq gene models",
-		     'rnaseq_bam'  => $sample_name." RNA-seq BWA alignments",
+		     'rnaseq_bam'  => $sample_name." RNA-seq alignments",
 		     'rnaseq_ise'  => $sample_name." intron-spanning reads",
 	             'rnaseq_daf'  => $sample_name." intron-spanning reads",
         	    );


### PR DESCRIPTION
Removed "BWA" from the description and the display label of the bam file rnaseq analyses because other programs are used too.

# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
Update.
_Include a short description_
The description and display_label mention BWA as aligner for the bam files but this is not always the case.
_Include links to JIRA tickets_
N/A.
# Testing
_Have you tested it?_
Not yet.
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
