### PR TITLE
Updated git clone to use ensembl-git-tools instead to enable fallback…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,18 +23,20 @@ addons:
         - graphviz
 
 before_install:
-    - git clone --depth 1 https://github.com/Ensembl/ensembl.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-variation.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-taxonomy.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-external.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-killlist.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-pipeline.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-compara.git
-    - git clone --branch release/90 --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-hive.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-io.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-test.git
-    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-production.git
+    - git clone --depth 1 https://github.com/Ensembl/ensembl-git-tools.git
+    - export PATH=$PATH:$PWD/ensembl-git-tools/bin
+    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl
+    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-variation
+    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-taxonomy
+    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-external
+    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-killlist
+    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-pipeline
+    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-compara
+    - git-ensembl --clone --branch release/90 --depth 1 ensembl-funcgen
+    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-hive
+    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-io
+    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-test
+    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-production
 #    We need the repo to be public or to have a token to use it. If this is uncommented
 #    you also need to update travisci/harness.sh
     - git clone --branch master --depth 1 https://github.com/Ensembl/GIFTS.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ before_install:
     - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl
     - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-variation
     - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-taxonomy
-    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-external
-    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-killlist
-    - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-pipeline
+    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-external.git
+    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-killlist.git
+    - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-pipeline.git
     - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-compara
     - git-ensembl --clone --branch release/90 --depth 1 ensembl-funcgen
     - git-ensembl --clone --branch master --secondary_branch main --depth 1 ensembl-hive


### PR DESCRIPTION
… branch to main


# PR details
_Is this a fix/ update/ new feature?_

This is a fixture :-)

_Include a short description_

Use ensembl-git-tools to default to main in case master disappeared

_Include links to JIRA tickets_

None

# Testing
_Have you tested it?_

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
