### PR TITLE
Set mapping db to undef

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -87,7 +87,7 @@ sub default_options {
     stable_id_start                  => '0', # When mapping is not required this is usually set to 0
     stable_id_prefix                 => '', # e.g. ENSPTR. When running a new annotation look up prefix in the assembly registry db
     mapping_required                 => '0', # If set to 1 this will run stable_id mapping sometime in the future. At the moment it does nothing
-    mapping_db                       => '', # Tied to mapping_required being set to 1, we should have a mapping db defined in this case, leave undef for now
+    mapping_db                       => 'undef', # Tied to mapping_required being set to 1, we should have a mapping db defined in this case, leave undef for now
 
     paired_end_only                  => '1', # Will only use paired-end rnaseq data if 1
     rnaseq_study_accession           => '', # A study accession for a transcriptomic dataset, if provided, only this data will be used


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix
Yes
_Include a short description_
The empty value set for parameter mapping_id is not being taken by the module FinaliseCoreDB. Thus, the parameter -stable_prefix_id is being used and this makes the run_stable_id analysis to fail.
_Include links to JIRA tickets_
https://www.ebi.ac.uk/panda/jira/browse/ENSGENEBUI-697
# Testing
Yes

# Assign to the weekly GitHub reviewer
@ens-ftricomi 
