### PR TITLE
Updated Stars default value for --limitSjdbInsertNsj to two million

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Runnable/Star.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Runnable/Star.pm
@@ -116,7 +116,7 @@ sub run {
   $options .= ' --outSAMattributes "'.$self->sam_attributes.'"' if ($self->sam_attributes);
 
   # run STAR
-  my $command = $self->program." --outFilterIntronMotifs RemoveNoncanonicalUnannotated --outSAMstrandField intronMotif --runThreadN ".$self->threads." --twopassMode Basic --runMode alignReads --genomeDir ".$self->genome." --readFilesIn $fastq $fastqpair --outFileNamePrefix $out_dir $options --outTmpDir $tmp_dir --outSAMtype BAM SortedByCoordinate";
+  my $command = $self->program." --limitSjdbInsertNsj 2000000 --outFilterIntronMotifs RemoveNoncanonicalUnannotated --outSAMstrandField intronMotif --runThreadN ".$self->threads." --twopassMode Basic --runMode alignReads --genomeDir ".$self->genome." --readFilesIn $fastq $fastqpair --outFileNamePrefix $out_dir $options --outTmpDir $tmp_dir --outSAMtype BAM SortedByCoordinate";
   $self->warning("Command: $command\n");
   execute_with_wait($command);
   $self->output([$out_dir.'Aligned.sortedByCoord.out.bam']);


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
A fix
_Include a short description_
Star fails for genomes where processing requires a higher amount of junctions to be inserted
_Include links to JIRA tickets_
https://www.ebi.ac.uk/panda/jira/projects/ENSGENEBUI/issues/ENSGENEBUI-668?filter=reportedbyme
# Testing
_Have you tested it?_
Yes
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
@leannehaggerty 