### PR TITLE
Added new biotypes to gencode_basic script

### DIFF
--- a/scripts/Merge/label_gencode_basic_transcripts.pl
+++ b/scripts/Merge/label_gencode_basic_transcripts.pl
@@ -166,6 +166,7 @@ my $biotype2group = get_biotype_groups($production_db);
 my $known_biotypes = {
                      'protein_coding'                     => 'coding',
                      'polymorphic_pseudogene'             => 'coding',
+                     'protein_coding_LoF'                 => 'coding',
                      'IG_D_gene'                          => 'coding',
                      'IG_J_gene'                          => 'coding',
                      'IG_C_gene'                          => 'coding',
@@ -196,6 +197,7 @@ my $known_biotypes = {
                      'sRNA'                               => 'noncoding_second_choice',
                      'vault_RNA'                          => 'noncoding_second_choice',
                      'processed_transcript'               => 'noncoding_second_choice',
+                     'protein_coding_CDS_not_defined'     => 'noncoding_second_choice',
                      'misc_RNA'                           => 'noncoding_second_choice',
                      '3prime_overlapping_ncRNA'           => 'noncoding_second_choice',
                      'non_coding'                         => 'noncoding_second_choice',
@@ -229,6 +231,7 @@ my $known_biotypes = {
                      'TEC'                                => 'problem',
                      'ambiguous_orf'                      => 'problem',
                      'disrupted_domain'                   => 'problem',
+                     'artifact'                           => 'problem',
                      'LRG_gene'                           => 'do_not_use',
                      };
 


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
Update

_Include a short description_
The script that creates the 'gencode_basic' attributes in the human and mouse core databases has been updated with new transcript biotypes:
-protein_coding_LoF
-protein_coding_CDS_not_defined
-artifact

_Include links to JIRA tickets_

# Testing
_Have you tested it?_
Yes

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
