### PR TITLE
Lowered min counts for fish_basic for layering in SanityChecksStatic.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
@@ -550,6 +550,11 @@ sub _master_config {
          }, # biotypes
       }, # rnaseq_blast
       'layer' => {
+        'logic_names' =>    {
+          'genblast'                => 10000,
+          'best_targetted'          => 1000,
+          'genblast_rnaseq_support' => 10000,
+        }, # logic_names
         'biotypes' =>    {
           'IG_'                  => 0,
           'TR_'                  => 0,

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
@@ -554,11 +554,11 @@ sub _master_config {
           'IG_'                  => 0,
           'TR_'                  => 0,
           'human_pe12_'          => 0,
-          'mouse_pe12_'       => 15000,
-          'vert_pe12_'       => 300,
-          'mammals_pe12_'        => 12000,
+          'mouse_pe12_'       => 0,
+          'vert_pe12_'       => 200,
+          'mammals_pe12_'        => 500,
           'realign_'             => 0,
-          'rnaseq_merged_'       => 10000,
+          'rnaseq_merged_'       => 0,
           'rnaseq_tissue_'       => 149000,
         }, # biotypes
       }, # layer


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
Update.
_Include a short description_
The fish_basic min counts for layer annotation sanity check are a bit high for some fish species like medaka, salmon, etc. so I've decreased them.
_Include links to JIRA tickets_
N/A
# Testing
_Have you tested it?_
Yes.
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
