### PR TITLE
Add CLI parameter if value is defined or 0

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveMetaPipelineInit.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveMetaPipelineInit.pm
@@ -144,7 +144,9 @@ sub fetch_input {
         else {
           # We need to make sure that an arrayref/hashref is correctly passed to the init script
           my $value = ref($extra_parameters->{$key}) ? stringify($extra_parameters->{$key}) : $extra_parameters->{$key};
-          push(@cmd, "-$key", $value) if (defined($value));
+          if ($value or (defined $value and $value eq "0")) {
+            push(@cmd, "-$key", $value) if ($value);
+          }
         }
       }
     }


### PR DESCRIPTION
This fixes the problem with the meta table where the meta key
repeat.analysis is wrong for repeatmasker. The problem comes from
parameters being added to the command line even if the value is empty
string.
Now the value needs to be "true" or 0

# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
fix

_Include a short description_
This fixes the problem with the meta table where the meta key
repeat.analysis is wrong for repeatmasker. The problem comes from
parameters being added to the command line even if the value is empty
string.
Now the value needs to be "true" or 0

_Include links to JIRA tickets_

# Testing
_Have you tested it?_
No, but it is trivial enough. However only a full run of the pipeline would fully test any possible problem

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
