### PR TITLE
Added sequence location attribute for MT entry in seq_region_attrib

### DIFF
--- a/scripts/refseq/load_mitochondria.pl
+++ b/scripts/refseq/load_mitochondria.pl
@@ -269,6 +269,14 @@ if (!$slice) {
   $slice = $slice_adaptor->fetch_by_region('toplevel',$MIT_NAME);
 }
 
+#Add sequence location attribute to seq_region_table
+my $satrb = $output_db->get_AttributeAdaptor();
+my $seq_loc_attribute = Bio::EnsEMBL::Attribute->new(
+  -CODE        => 'sequence_location',
+  -VALUE       => 'mitochondrial_chromosome',
+);
+$satrb->store_on_Slice( $slice, [$seq_loc_attribute]);
+
 # Trying to add karyotype_rank attribute if we have chromosomes
 my $max_attrib = 0;
 foreach my $chromosome (@{$slice->adaptor->fetch_all_karyotype}) {


### PR DESCRIPTION
…able

# Requirements
When creating your Pull request, please fill out the template below:

# PR details
update

_Include a short description_
Production has updated the list of master attributes to now require a sequence location attribute be stored for MT entries in the seq region table

_Include links to JIRA tickets_
https://www.ebi.ac.uk/panda/jira/browse/ENSGENEBUI-660

# Testing
Tested by loading running the load_mitochondrion script on a species with MT

# Assign to the weekly GitHub reviewer
@ens-carlos 
