### PR TITLE
Set refine db to rnalayer_nr instead of undef in Homology RNASeq

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -1666,7 +1666,7 @@ sub pipeline_analyses {
         hive_config => $self->o('hive_homology_rnaseq_config'),
         databases => ['genblast_db', 'rnaseq_refine_db', 'genblast_rnaseq_support_nr_db', 'dna_db'],
         genblast_db => $self->o('genblast_db'),
-        rnaseq_refine_db => undef,
+        rnaseq_refine_db => $self->o('rnaseq_for_layer_nr_db'),
         genblast_rnaseq_support_nr_db => $self->o('genblast_rnaseq_support_nr_db'),
         dna_db => $self->o('dna_db'),
         enscode_root_dir => $self->o('enscode_root_dir'),


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
A fix

_Include a short description_
The value for refine_db parameter was set tu undef in initialise Homology RNASeq. This ought to be have been set to some other value so the analysis does not fail when run.

_Include links to JIRA tickets_

# Testing
Yes

# Assign to the weekly GitHub reviewer
@thibauthourlier 
