### PR TITLE
update sanity checks to exclude verts_pe12 for mammals - this is not …

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
@@ -149,7 +149,6 @@ sub _master_config {
         'biotypes' =>    {
           'human_pe12_'         => 20000,
           'mouse_pe12_'      => 50000,
-          'vert_pe12_'      => 50000,
           'mammals_pe12_'       => 100000,
         }, # biotypes
       }, # genblast
@@ -627,7 +626,6 @@ sub _master_config {
         'biotypes' =>    {
           'human_pe12_'         => 20000,
           'mouse_pe12_'      => 50000,
-          'vert_pe12_'      => 50000,
           'mammals_pe12_'       => 100000,
         }, # biotypes
       }, # genblast


### PR DESCRIPTION
…downloaded at DownloadUniprot

# Requirements
When creating your Pull request, please fill out the template below:

# PR details
Sanity checks were expecting biotype "vert_pe12" for mammals basic but file was not dowloaded in mammals basic uniprot set

# Testing
yes

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
