### PR TITLE
Use only gca instead of production_name for the dbnames

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/BestTargetted_subpipeline.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/BestTargetted_subpipeline.pm
@@ -60,6 +60,7 @@ sub default_options {
     'release_number' => '' || $self->o('ensembl_release'),
     'species_name'    => '',     # e.g. mus_musculus
     'production_name' => '',     # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
 
     'taxon_id'    => '',         # should be in the assembly report file
     use_genome_flatfile => 1,
@@ -99,8 +100,8 @@ sub default_options {
     # These values can be replaced in the analysis_base table if they're not known yet
     # If they are not needed (i.e. no projection or rnaseq) then leave them as is
 
-    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('production_name') . '_pipe_' . $self->o('release_number'),
-    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('production_name') . '_core_' . $self->o('release_number'),
+    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_pipe_' . $self->o('release_number'),
+    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_core_' . $self->o('release_number'),
 
     'cdna_db_host'   => $self->o('databases_host'),
     'cdna_db_port'   => $self->o('databases_port'),
@@ -143,7 +144,7 @@ sub default_options {
     ########################
 
     'cdna_db' => {
-      -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_cdna_' . $self->o('release_number'),
+      -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_cdna_' . $self->o('release_number'),
       -host   => $self->o('cdna_db_host'),
       -port   => $self->o('cdna_db_port'),
       -user   => $self->o('user'),
@@ -152,7 +153,7 @@ sub default_options {
     },
 
     'cdna2genome_db' => {
-      -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_cdna2genome_' . $self->o('release_number'),
+      -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_cdna2genome_' . $self->o('release_number'),
       -host   => $self->o('cdna2genome_db_host'),
       -port   => $self->o('cdna2genome_db_port'),
       -user   => $self->o('user'),
@@ -161,7 +162,7 @@ sub default_options {
     },
 
     'genewise_db' => {
-      -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_genewise_' . $self->o('release_number'),
+      -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_genewise_' . $self->o('release_number'),
       -host   => $self->o('genewise_db_host'),
       -port   => $self->o('genewise_db_port'),
       -user   => $self->o('user'),
@@ -170,7 +171,7 @@ sub default_options {
     },
 
     'best_targeted_db' => {
-      -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_bt_' . $self->o('release_number'),
+      -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_bt_' . $self->o('release_number'),
       -host   => $self->o('best_targeted_db_host'),
       -port   => $self->o('best_targeted_db_port'),
       -user   => $self->o('user'),

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/FinaliseCoreDB.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/FinaliseCoreDB.pm
@@ -57,6 +57,7 @@ sub default_options {
     'registry_db'        => '',                                                                                                # name for registry db
     'species_name'       => '',                                                                                                # e.g. mus_musculus
     'production_name'    => '',                                                                                                # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     'release_number'     => '' || $self->o('ensembl_release'),
     'uniprot_set'        => '',                                                                                                # e.g. mammals_basic, check UniProtCladeDownloadStatic.pm module in hive config dir for suitable set,
     'sanity_set'         => '',                                                                                                # sanity checks
@@ -79,8 +80,8 @@ sub default_options {
 
     'projection_source_db_name'         => '',                                                                                 # This is generally a pre-existing db, like the current human/mouse core for example
 
-    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('production_name') . '_pipe_' . $self->o('release_number'),
-    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('production_name') . '_core_' . $self->o('release_number'),
+    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_pipe_' . $self->o('release_number'),
+    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_core_' . $self->o('release_number'),
 
     'reference_db_name'   => $self->o('dna_db_name'),
     'reference_db_host'   => $self->o('dna_db_host'),
@@ -135,7 +136,7 @@ sub default_options {
     },
 
     'final_geneset_db' => {
-      -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_final_' . $self->o('release_number'),
+      -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_final_' . $self->o('release_number'),
       -host   => $self->o('final_geneset_db_host'),
       -port   => $self->o('final_geneset_db_port'),
       -user   => $self->o('user'),

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/GenblastHomology.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/GenblastHomology.pm
@@ -57,6 +57,7 @@ sub default_options {
     'release_number'   => '' || $self->o('ensembl_release'),
     'species_name'     => '',                                  # e.g. mus_musculus
     'production_name'  => '',                                  # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     'taxon_id'         => '',                                  # should be in the assembly report file
     'uniprot_set'      => '',                                  # e.g. mammals_basic, check UniProtCladeDownloadStatic.pm module in hive config dir for suitable set,
     'sanity_set'       => '',                                  # sanity_checks
@@ -70,8 +71,8 @@ sub default_options {
 # These values can be replaced in the analysis_base table if they're not known yet
 # If they are not needed (i.e. no projection or rnaseq) then leave them as is
 
-    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('production_name') . '_pipe_' . $self->o('release_number'),
-    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('production_name') . '_core_' . $self->o('release_number'),
+    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_pipe_' . $self->o('release_number'),
+    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_core_' . $self->o('release_number'),
 
     'genblast_db_host'   => $self->o('databases_host'),
     'genblast_db_port'   => $self->o('databases_port'),
@@ -131,7 +132,7 @@ sub default_options {
 ########################
 
     'genblast_db' => {
-      -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_genblast_' . $self->o('release_number'),
+      -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_genblast_' . $self->o('release_number'),
       -host   => $self->o('genblast_db_host'),
       -port   => $self->o('genblast_db_port'),
       -user   => $self->o('user'),
@@ -140,7 +141,7 @@ sub default_options {
     },
 
     'genblast_nr_db' => {
-      -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_genblast_nr_' . $self->o('release_number'),
+      -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_genblast_nr_' . $self->o('release_number'),
       -host   => $self->o('genblast_nr_db_host'),
       -port   => $self->o('genblast_nr_db_port'),
       -user   => $self->o('user'),

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -61,6 +61,7 @@ sub default_options {
     release_number                   => '' || $ENV{ENSEMBL_RELEASE},
     species_name                     => '', # e.g. mus_musculus
     production_name                  => '', # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession                 => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     taxon_id                         => '', # should be in the assembly report file
     species_taxon_id                 => '' || $self->o('taxon_id'), # Species level id, could be different to taxon_id if we have a subspecies, used to get species level RNA-seq CSV data
     genus_taxon_id                   => '' || $self->o('taxon_id'), # Genus level taxon id, used to get a genus level csv file in case there is not enough species level transcriptomic data
@@ -140,8 +141,8 @@ sub default_options {
 ########################
 # Pipe and ref db info
 ########################
-    pipe_db_name                  => $self->o('dbowner').'_'.$self->o('production_name').'_pipe_'.$self->o('release_number'),
-    dna_db_name                   => $self->o('dbowner').'_'.$self->o('production_name').'_core_'.$self->o('release_number'),
+    pipe_db_name                  => $self->o('dbowner').'_'.$self->o('dbname_accession').'_pipe_'.$self->o('release_number'),
+    dna_db_name                   => $self->o('dbowner').'_'.$self->o('dbname_accession').'_core_'.$self->o('release_number'),
 
     reference_db_name            => $self->o('dna_db_name'),
     reference_db_host            => $self->o('dna_db_host'),
@@ -292,7 +293,7 @@ sub default_options {
     },
 
     refseq_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_refseq_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_refseq_'.$self->o('release_number'),
       -host   => $self->o('refseq_db_host'),
       -port   => $self->o('refseq_db_port'),
       -user   => $self->o('user'),
@@ -319,7 +320,7 @@ sub default_options {
     },
 
     selected_projection_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_sel_proj_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_sel_proj_'.$self->o('release_number'),
       -host   => $self->o('projection_db_host'),
       -port   => $self->o('projection_db_port'),
       -user   => $self->o('user'),
@@ -328,7 +329,7 @@ sub default_options {
     },
 
     genblast_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_genblast_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_genblast_'.$self->o('release_number'),
       -host   => $self->o('genblast_db_host'),
       -port   => $self->o('genblast_db_port'),
       -user   => $self->o('user'),
@@ -337,7 +338,7 @@ sub default_options {
     },
 
     genblast_nr_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_genblast_nr_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_genblast_nr_'.$self->o('release_number'),
       -host   => $self->o('genblast_nr_db_host'),
       -port   => $self->o('genblast_nr_db_port'),
       -user   => $self->o('user'),
@@ -346,7 +347,7 @@ sub default_options {
     },
 
     cdna_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_cdna_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_cdna_'.$self->o('release_number'),
       -host   => $self->o('cdna_db_host'),
       -port   => $self->o('cdna_db_port'),
       -user   => $self->o('user'),
@@ -355,7 +356,7 @@ sub default_options {
     },
 
     best_targeted_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_bt_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_bt_'.$self->o('release_number'),
       -host   => $self->o('best_targeted_db_host'),
       -port   => $self->o('best_targeted_db_port'),
       -user   => $self->o('user'),
@@ -364,7 +365,7 @@ sub default_options {
     },
 
     ig_tr_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_igtr_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_igtr_'.$self->o('release_number'),
       -host   => $self->o('ig_tr_db_host'),
       -port   => $self->o('ig_tr_db_port'),
       -user   => $self->o('user'),
@@ -373,7 +374,7 @@ sub default_options {
     },
 
     ncrna_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_ncrna_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_ncrna_'.$self->o('release_number'),
       -host   => $self->o('ncrna_db_host'),
       -port   => $self->o('ncrna_db_port'),
       -user   => $self->o('user'),
@@ -382,7 +383,7 @@ sub default_options {
     },
 
     rnaseq_refine_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_refine_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_refine_'.$self->o('release_number'),
       -host   => $self->o('rnaseq_refine_db_host'),
       -port   => $self->o('rnaseq_refine_db_port'),
       -user   => $self->o('user'),
@@ -391,7 +392,7 @@ sub default_options {
     },
 
     rnaseq_blast_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_scallop_blast_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_scallop_blast_'.$self->o('release_number'),
       -host   => $self->o('rnaseq_blast_db_host'),
       -port   => $self->o('rnaseq_blast_db_port'),
       -user   => $self->o('user'),
@@ -400,7 +401,7 @@ sub default_options {
     },
 
     rnaseq_for_layer_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_rnaseq_layer_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_rnaseq_layer_'.$self->o('release_number'),
       -host   => $self->o('rnaseq_for_layer_db_host'),
       -port   => $self->o('rnaseq_for_layer_db_port'),
       -user   => $self->o('user'),
@@ -409,7 +410,7 @@ sub default_options {
     },
 
     rnaseq_for_layer_nr_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_rnalayer_nr_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_rnalayer_nr_'.$self->o('release_number'),
       -host   => $self->o('rnaseq_for_layer_nr_db_host'),
       -port   => $self->o('rnaseq_for_layer_nr_db_port'),
       -user   => $self->o('user'),
@@ -418,7 +419,7 @@ sub default_options {
     },
 
     pcp_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_pcp_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_pcp_'.$self->o('release_number'),
       -host   => $self->o('pcp_db_host'),
       -port   => $self->o('pcp_db_port'),
       -user   => $self->o('user'),
@@ -427,7 +428,7 @@ sub default_options {
     },
 
     pcp_nr_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_pcp_nr_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_pcp_nr_'.$self->o('release_number'),
       -host   => $self->o('pcp_db_host'),
       -port   => $self->o('pcp_db_port'),
       -user   => $self->o('user'),
@@ -436,7 +437,7 @@ sub default_options {
     },
 
     long_read_final_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_lrfinal_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_lrfinal_'.$self->o('release_number'),
       -host => $self->o('long_read_final_db_host'),
       -port => $self->o('long_read_final_db_port'),
       -user => $self->o('user'),
@@ -445,7 +446,7 @@ sub default_options {
     },
 
     genblast_rnaseq_support_nr_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_gb_rnaseq_nr_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_gb_rnaseq_nr_'.$self->o('release_number'),
       -host   => $self->o('genblast_rnaseq_support_db_host'),
       -port   => $self->o('genblast_rnaseq_support_db_port'),
       -user   => $self->o('user'),
@@ -454,7 +455,7 @@ sub default_options {
     },
 
     final_geneset_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_final_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_final_'.$self->o('release_number'),
       -host   => $self->o('final_geneset_db_host'),
       -port   => $self->o('final_geneset_db_port'),
       -user   => $self->o('user'),
@@ -463,7 +464,7 @@ sub default_options {
     },
 
     rnaseq_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_rnaseq_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_rnaseq_'.$self->o('release_number'),
       -host   => $self->o('rnaseq_db_host'),
       -port   => $self->o('rnaseq_db_port'),
       -user   => $self->o('user'),
@@ -472,7 +473,7 @@ sub default_options {
     },
 
     otherfeatures_db => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_otherfeatures_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_otherfeatures_'.$self->o('release_number'),
       -host   => $self->o('otherfeatures_db_host'),
       -port   => $self->o('otherfeatures_db_port'),
       -user   => $self->o('user'),
@@ -558,7 +559,7 @@ sub pipeline_analyses {
   my $db_name_template = "%s_%s_%s_%s";
   my ($load_assembly_pipe_db, $load_assembly_pipe_url, $load_assembly_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'load_assembly_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'load_assembly_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -566,7 +567,7 @@ sub pipeline_analyses {
     );
   my ($repeat_masking_pipe_db, $repeat_masking_pipe_url, $repeat_masking_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'repeat_masking_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'repeat_masking_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -574,7 +575,7 @@ sub pipeline_analyses {
     );
   my ($refseq_import_pipe_db, $refseq_import_pipe_url, $refseq_import_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'refseq_import_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'refseq_import_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -582,7 +583,7 @@ sub pipeline_analyses {
     );
   my ($lastz_pipe_db, $lastz_pipe_url, $lastz_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'lastz_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'lastz_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -590,7 +591,7 @@ sub pipeline_analyses {
     );
   my ($projection_pipe_db, $projection_pipe_url, $projection_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'projection_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'projection_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -598,7 +599,7 @@ sub pipeline_analyses {
     );
   my ($homology_pipe_db, $homology_pipe_url, $homology_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'homology_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'homology_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -606,7 +607,7 @@ sub pipeline_analyses {
     );
   my ($best_targeted_pipe_db, $best_targeted_pipe_url, $best_targeted_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'best_targeted_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'best_targeted_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -614,7 +615,7 @@ sub pipeline_analyses {
     );
   my ($igtr_pipe_db, $igtr_pipe_url, $igtr_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'igtr_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'igtr_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -622,7 +623,7 @@ sub pipeline_analyses {
     );
   my ($short_ncrna_pipe_db, $short_ncrna_pipe_url, $short_ncrna_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'short_ncrna_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'short_ncrna_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -630,7 +631,7 @@ sub pipeline_analyses {
     );
   my ($rnaseq_pipe_db, $rnaseq_pipe_url, $rnaseq_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'rnaseq_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'rnaseq_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -638,7 +639,7 @@ sub pipeline_analyses {
     );
   my ($long_read_pipe_db, $long_read_pipe_url, $long_read_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'long_read_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'long_read_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -646,7 +647,7 @@ sub pipeline_analyses {
     );
   my ($homology_rnaseq_pipe_db, $homology_rnaseq_pipe_url, $homology_rnaseq_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'homology_rnaseq_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'homology_rnaseq_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -654,7 +655,7 @@ sub pipeline_analyses {
     );
   my ($transcript_selection_pipe_db, $transcript_selection_pipe_url, $transcript_finalisation_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'set_finalisation_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'set_finalisation_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -662,7 +663,7 @@ sub pipeline_analyses {
     );
   my ($core_db_finalisation_pipe_db, $core_db_finalisation_pipe_url, $core_db_finalisation_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'db_finalisation_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'db_finalisation_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -670,7 +671,7 @@ sub pipeline_analyses {
     );
   my ($otherfeatures_db_pipe_db, $otherfeatures_db_pipe_url, $otherfeatures_db_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'otherfeatures_db_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'otherfeatures_db_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -678,7 +679,7 @@ sub pipeline_analyses {
     );
   my ($rnaseq_db_pipe_db, $rnaseq_db_pipe_url, $rnaseq_db_guihive) = $self->get_meta_db_information(
       undef,
-      sprintf($db_name_template, $self->o('dbowner'), $self->o('production_name'), 'rnaseq_db_pipe', $self->o('release_number')),
+      sprintf($db_name_template, $self->o('dbowner'), $self->o('dbname_accession'), 'rnaseq_db_pipe', $self->o('release_number')),
       $self->o('pipe_db_host'),
       $self->o('pipe_db_port'),
       $self->o('pipe_db_user'),
@@ -788,6 +789,7 @@ sub pipeline_analyses {
           release_number => $self->o('release_number'),
           species_name => $self->o('species_name'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           taxon_id => $self->o('taxon_id'),
           wgs_id => $self->o('wgs_id'),
           assembly_name => $self->o('assembly_name'),
@@ -886,6 +888,7 @@ sub pipeline_analyses {
           databases_port => $self->o('databases_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           assembly_name => $self->o('assembly_name'),
           assembly_refseq_accession => $self->o('assembly_refseq_accession'),
         },
@@ -941,6 +944,7 @@ sub pipeline_analyses {
           dna_db_port => $self->o('dna_db_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           repbase_logic_name => $self->o('repbase_logic_name'),
           repbase_library => $self->o('repbase_library'),
           species_name => $self->o('species_name'),
@@ -1057,6 +1061,7 @@ sub pipeline_analyses {
           databases_port => $self->o('databases_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           species_name => $self->o('species_name'),
           use_genome_flatfile => $self->o('use_genome_flatfile'),
           skip_projection => $self->o('skip_projection'),
@@ -1245,6 +1250,7 @@ sub pipeline_analyses {
           dna_db_port => $self->o('dna_db_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           species_name => $self->o('species_name'),
           registry_file => $self->o('registry_file'),
           projection_source_db_name => $self->o('projection_source_db_name'),
@@ -1329,6 +1335,7 @@ sub pipeline_analyses {
           databases_port => $self->o('databases_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           projection_source_db_name => $self->o('projection_source_db_name'),
           uniprot_set => $self->o('uniprot_set'),
           sanity_set => $self->o('sanity_set'),
@@ -1390,6 +1397,7 @@ sub pipeline_analyses {
           databases_port => $self->o('databases_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           species_name => $self->o('species_name'),
           taxon_id => $self->o('taxon_id'),
           uniprot_set => $self->o('uniprot_set'),
@@ -1452,6 +1460,7 @@ sub pipeline_analyses {
           databases_port => $self->o('databases_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           species_name => $self->o('species_name'),
           taxon_id => $self->o('taxon_id'),
           wide_repeat_logic_names => '#wide_repeat_logic_names#',
@@ -1511,6 +1520,7 @@ sub pipeline_analyses {
           databases_port => $self->o('databases_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           species_name => $self->o('species_name'),
           uniprot_set => $self->o('uniprot_set'),
           sanity_set => $self->o('sanity_set'),
@@ -1594,6 +1604,7 @@ sub pipeline_analyses {
           databases_port => $self->o('databases_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           species_name => $self->o('species_name'),
           taxon_id => $self->o('taxon_id'),
           sanity_set => $self->o('sanity_set'),
@@ -1679,6 +1690,7 @@ sub pipeline_analyses {
           databases_port => $self->o('databases_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           species_name => $self->o('species_name'),
           uniprot_set => $self->o('uniprot_set'),
           sanity_set => $self->o('sanity_set'),
@@ -1733,6 +1745,7 @@ sub pipeline_analyses {
           release_number => $self->o('release_number'),
           assembly_name => $self->o('assembly_name'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           species_name => $self->o('species_name'),
           taxon_id => $self->o('taxon_id'),
           uniprot_set => $self->o('uniprot_set'),
@@ -1821,6 +1834,7 @@ sub pipeline_analyses {
           databases_port => $self->o('databases_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           species_name => $self->o('species_name'),
           long_read_summary_file => $self->o('long_read_summary_file'),
           long_read_summary_file_genus => $self->o('long_read_summary_file_genus'),
@@ -1884,6 +1898,7 @@ sub pipeline_analyses {
           databases_port => $self->o('databases_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           species_name => $self->o('species_name'),
           uniprot_set => $self->o('uniprot_set'),
           sanity_set => $self->o('sanity_set'),
@@ -1983,6 +1998,7 @@ sub pipeline_analyses {
           databases_port => $self->o('databases_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           species_name => $self->o('species_name'),
           registry_host => $self->o('registry_host'),
           registry_port => $self->o('registry_port'),
@@ -2059,6 +2075,7 @@ sub pipeline_analyses {
           databases_port => $self->o('databases_port'),
           release_number => $self->o('release_number'),
           production_name => $self->o('production_name'),
+          dbname_accession => $self->o('dbname_accession'),
           species_name => $self->o('species_name'),
           registry_host => $self->o('registry_host'),
           registry_port => $self->o('registry_port'),

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/HomologyRnaseq.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/HomologyRnaseq.pm
@@ -53,6 +53,7 @@ sub default_options {
     'release_number'                  => '' || $self->o('ensembl_release'),
     'species_name'                    => '', # e.g. mus_musculus
     'production_name'                 => '', # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     'uniprot_set'                     => '', # e.g. mammals_basic, check UniProtCladeDownloadStatic.pm module in hive config dir for suitable set,
     'use_genome_flatfile'             => '1',# This will read sequence where possible from a dumped flatfile instead of the core db
     'output_path'                     => '', # Lustre output dir. This will be the primary dir to house the assembly info and various things from analyses
@@ -61,8 +62,8 @@ sub default_options {
 # Pipe and ref db info
 ########################
 
-    'pipe_db_name'                  => $self->o('dbowner').'_'.$self->o('production_name').'_pipe_'.$self->o('release_number'),
-    'dna_db_name'                   => $self->o('dbowner').'_'.$self->o('production_name').'_core_'.$self->o('release_number'),
+    'pipe_db_name'                  => $self->o('dbowner').'_'.$self->o('dbname_accession').'_pipe_'.$self->o('release_number'),
+    'dna_db_name'                   => $self->o('dbowner').'_'.$self->o('dbname_accession').'_core_'.$self->o('release_number'),
 
     'genblast_db_host'             => $self->o('databases_host'),
     'genblast_db_port'             => $self->o('databases_port'),
@@ -72,7 +73,7 @@ sub default_options {
 
     'rnaseq_refine_db_host'         => $self->o('databases_host'),
     'rnaseq_refine_db_port'         => $self->o('databases_port'),
-    'rnaseq_refine_db_name'         => $self->o('dbowner').'_'.$self->o('production_name').'_refine_'.$self->o('release_number'),
+    'rnaseq_refine_db_name'         => $self->o('dbowner').'_'.$self->o('dbname_accession').'_refine_'.$self->o('release_number'),
 
     # This is used for the ensembl_production and the ncbi_taxonomy databases
     'ensembl_release'              => $ENV{ENSEMBL_RELEASE}, # this is the current release version on staging to be able to get the correct database
@@ -99,7 +100,7 @@ sub default_options {
 # db info
 ########################
     'genblast_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_genblast_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_genblast_'.$self->o('release_number'),
       -host   => $self->o('genblast_db_host'),
       -port   => $self->o('genblast_db_port'),
       -user   => $self->o('user'),
@@ -108,7 +109,7 @@ sub default_options {
     },
 
     'genblast_rnaseq_support_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_gb_rnaseq_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_gb_rnaseq_'.$self->o('release_number'),
       -host   => $self->o('genblast_rnaseq_support_db_host'),
       -port   => $self->o('genblast_rnaseq_support_db_port'),
       -user   => $self->o('user'),
@@ -117,7 +118,7 @@ sub default_options {
     },
 
     'genblast_rnaseq_support_nr_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_gb_rnaseq_nr_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_gb_rnaseq_nr_'.$self->o('release_number'),
       -host   => $self->o('genblast_rnaseq_support_db_host'),
       -port   => $self->o('genblast_rnaseq_support_db_port'),
       -user   => $self->o('user'),

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/IGTR_subpipeline.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/IGTR_subpipeline.pm
@@ -56,6 +56,7 @@ sub default_options {
     'release_number'            => '' || $self->o('ensembl_release'),
     'species_name'              => '', # e.g. mus_musculus
     'production_name'           => '', # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
 
     # need for IGTR part:
     'ig_tr_fasta_file'          => 'human_ig_tr.fa', # What IMGT fasta file to use. File should contain protein segments with appropriate headers
@@ -70,8 +71,8 @@ sub default_options {
 # These values can be replaced in the analysis_base table if they're not known yet
 # If they are not needed (i.e. no projection or rnaseq) then leave them as is
 
-    'pipe_db_name'                  => $self->o('dbowner').'_'.$self->o('production_name').'_pipe_'.$self->o('release_number'),
-    'dna_db_name'                   => $self->o('dbowner').'_'.$self->o('production_name').'_core_'.$self->o('release_number'),
+    'pipe_db_name'                  => $self->o('dbowner').'_'.$self->o('dbname_accession').'_pipe_'.$self->o('release_number'),
+    'dna_db_name'                   => $self->o('dbowner').'_'.$self->o('dbname_accession').'_core_'.$self->o('release_number'),
 
     'ig_tr_db_host'                => $self->o('databases_host'),
     'ig_tr_db_port'                => $self->o('databases_port'),
@@ -123,7 +124,7 @@ sub default_options {
 ########################
 
     'ig_tr_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_igtr_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_igtr_'.$self->o('release_number'),
       -host   => $self->o('ig_tr_db_host'),
       -port   => $self->o('ig_tr_db_port'),
       -user   => $self->o('user'),

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/LastZ.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/LastZ.pm
@@ -55,6 +55,7 @@ sub default_options {
     'release_number' => '' || $self->o('ensembl_release'),
     'species_name'    => '',                                                          # e.g. mus_musculus
     'production_name' => '',                                                          # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     'output_path'     => '',                                                          # Lustre output dir. This will be the primary dir to house the assembly info and various things from analyses
     'registry_file'   => '' || catfile( $self->o('output_path'), "Databases.pm" ),    # Path to databse registry for LastaZ and Production sync
 
@@ -71,8 +72,8 @@ sub default_options {
     'compara_db_host'   => 'mysql-ens-genebuild-prod-5',
     'compara_db_port'   => 4531,
 
-    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('production_name') . '_pipe_' . $self->o('release_number'),
-    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('production_name') . '_core_' . $self->o('release_number'),
+    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_pipe_' . $self->o('release_number'),
+    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_core_' . $self->o('release_number'),
 
     # This is used for the ensembl_production and the ncbi_taxonomy databases
     'ensembl_release' => $ENV{ENSEMBL_RELEASE},    # this is the current release version on staging to be able to get the correct database

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/LoadAssembly.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/LoadAssembly.pm
@@ -53,6 +53,7 @@ sub default_options {
     release_number            => '' || $self->o('ensembl_release'),
     species_name              => '', # e.g. mus_musculus
     production_name           => '', # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     taxon_id                  => '', # should be in the assembly report file
     output_path               => '', # Lustre output dir. This will be the primary dir to house the assembly info and various things from analyses
     wgs_id                    => '', # Can be found in assembly report file on ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/
@@ -82,8 +83,8 @@ sub default_options {
 ########################
 # Pipe and ref db info
 ########################
-    pipe_db_name => $self->o('dbowner').'_'.$self->o('production_name').'_load_assembly_pipe_'.$self->o('release_number'),
-    dna_db_name  => $self->o('dbowner').'_'.$self->o('production_name').'_core_'.$self->o('release_number'),
+    pipe_db_name => $self->o('dbowner').'_'.$self->o('dbname_accession').'_load_assembly_pipe_'.$self->o('release_number'),
+    dna_db_name  => $self->o('dbowner').'_'.$self->o('dbname_accession').'_core_'.$self->o('release_number'),
 
     reference_db_name   => $self->o('dna_db_name'),
     reference_db_host   => $self->o('dna_db_host'),

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/OtherFeatureDb.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/OtherFeatureDb.pm
@@ -59,6 +59,7 @@ sub default_options {
     'release_number'            => '' || $self->o('ensembl_release'),
     'species_name'              => '',                                  # e.g. mus_musculus
     'production_name'           => '',                                  # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     'output_path'               => '',                                  # Lustre output dir. This will be the primary dir to house the assembly info and various things from analyses
     'assembly_name'             => '',                                  # Name (as it appears in the assembly report file)
     'assembly_accession'        => '',                                  # Versioned GCA assembly accession, e.g. GCA_001857705.1
@@ -71,10 +72,10 @@ sub default_options {
     # Pipe and ref db info
 ########################
 
-    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('production_name') . '_pipe_' . $self->o('release_number'),
-    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('production_name') . '_core_' . $self->o('release_number'),
+    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_pipe_' . $self->o('release_number'),
+    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_core_' . $self->o('release_number'),
 
-    otherfeatures_db_name => $self->o('dbowner').'_'.$self->o('production_name').'_otherfeatures_'.$self->o('release_number'),
+    otherfeatures_db_name => $self->o('dbowner').'_'.$self->o('dbname_accession').'_otherfeatures_'.$self->o('release_number'),
     'otherfeatures_db_host'   => $self->o('databases_host'),
     'otherfeatures_db_port'   => $self->o('databases_port'),
 
@@ -221,8 +222,8 @@ sub pipeline_analyses {
         read_only_user => $self->o('user_r'),
         dbowner => $self->o('dbowner'),
         release_number => $self->o('release_number'),
-        production_name => $self->o('production_name'),
-        cmd => q(if [[ -n `mysql -h #databases_host# -P #databases_port# -u #read_only_user# -NB -e "SHOW DATABASES LIKE '#dbowner#_#production_name#_#prefix#_#release_number#'"` ]]; then exit 0; else exit 42;fi),
+        dbname_accession => $self->o('dbname_accession'),
+        cmd => q(if [[ -n `mysql -h #databases_host# -P #databases_port# -u #read_only_user# -NB -e "SHOW DATABASES LIKE '#dbowner#_#dbname_accession#_#prefix#_#release_number#'"` ]]; then exit 0; else exit 42;fi),
 
         return_codes_2_branches => {'42' => 2},
       },
@@ -242,9 +243,9 @@ sub pipeline_analyses {
         read_only_user => $self->o('user_r'),
         dbowner => $self->o('dbowner'),
         release_number => $self->o('release_number'),
-        production_name => $self->o('production_name'),
+        dbname_accession => $self->o('dbname_accession'),
         min_threshold => $self->o('min_threshold_genes'),,
-        cmd => q(if [[ `mysql -h #databases_host# -P #databases_port# -u #read_only_user# #dbowner#_#production_name#_#prefix#_#release_number# -NB -e "SELECT COUNT(*) FROM gene"` -gt #min_threshold# ]]; then exit 0; else exit 42;fi),
+        cmd => q(if [[ `mysql -h #databases_host# -P #databases_port# -u #read_only_user# #dbowner#_#dbname_accession#_#prefix#_#release_number# -NB -e "SELECT COUNT(*) FROM gene"` -gt #min_threshold# ]]; then exit 0; else exit 42;fi),
 
         return_codes_2_branches => {'42' => 2},
       },
@@ -260,7 +261,7 @@ sub pipeline_analyses {
       -module     => 'Bio::EnsEMBL::Analysis::Hive::RunnableDB::HiveSubmitAnalysis',
       -parameters => {
         target_db => {
-          -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_#prefix#_' . $self->o('release_number'),
+          -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_#prefix#_' . $self->o('release_number'),
           -host   => $self->o('databases_host'),
           -port   => $self->o('databases_port'),
           -user   => $self->o('user'),
@@ -286,7 +287,7 @@ sub pipeline_analyses {
         logic_name => '#logic_name#',
         biotype => '#biotype#',
         source_db           => {
-          -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_#prefix#_' . $self->o('release_number'),
+          -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_#prefix#_' . $self->o('release_number'),
           -host   => $self->o('databases_host'),
           -port   => $self->o('databases_port'),
           -user   => $self->o('user'),
@@ -351,7 +352,7 @@ sub pipeline_analyses {
       -module => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
       -parameters => {
         cmd => 'perl '.$self->o('add_analyses_script').' -host #host# -port #port# -dbname #dbname#',
-        dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_#prefix#_' . $self->o('release_number'),
+        dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_#prefix#_' . $self->o('release_number'),
         host   => $self->o('databases_host'),
         port   => $self->o('databases_port'),
       },

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Projection_subpipeline_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Projection_subpipeline_conf.pm
@@ -44,6 +44,7 @@ sub default_options {
     'dbowner'                   => '' || $ENV{EHIVE_USER} || $ENV{USER},
     'pipeline_name'             => '' || $self->o('production_name').'_'.$self->o('ensembl_release'),
     'production_name'           => '', # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     'release_number'            => '' || $self->o('ensembl_release'),
     'user_r'                    => '', # read only db user
     'user'                      => '', # write db user
@@ -71,13 +72,13 @@ sub default_options {
     # The following might not be known in advance, since the come from other pipelines
     # These values can be replaced in the analysis_base table if they're not known yet
     # If they are not needed (i.e. no projection or rnaseq) then leave them as is
-    'pipe_db_name'  => $self->o('dbowner').'_'.$self->o('production_name').'_pipe_'.$self->o('release_number'),
+    'pipe_db_name'  => $self->o('dbowner').'_'.$self->o('dbname_accession').'_pipe_'.$self->o('release_number'),
 
-    'projection_lastz_db_name'     => $self->o('dbowner').'_'.$self->o('production_name').'_lastz_pipe_'.$self->o('release_number'),
+    'projection_lastz_db_name'     => $self->o('dbowner').'_'.$self->o('dbname_accession').'_lastz_pipe_'.$self->o('release_number'),
     'projection_lastz_db_host'     => $self->o('pipe_db_host'),
     'projection_lastz_db_port'     => $self->o('pipe_db_port'),
 
-    'dna_db_name'   => $self->o('dbowner').'_'.$self->o('production_name').'_core_'.$self->o('release_number'),
+    'dna_db_name'   => $self->o('dbowner').'_'.$self->o('dbname_accession').'_core_'.$self->o('release_number'),
     genome_dumps => catdir( $self->o('output_path'), 'genome_dumps' ),
     use_genome_flatfile => 1,
     faidx_genome_file => catfile( $self->o('genome_dumps'), $self->o('species_name') . '_toplevel.fa' ),
@@ -120,7 +121,7 @@ sub default_options {
 ########################
 
     'projection_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_proj_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_proj_'.$self->o('release_number'),
       -host   => $self->o('projection_db_host'),
       -port   => $self->o('projection_db_port'),
       -user   => $self->o('user'),
@@ -147,7 +148,7 @@ sub default_options {
     },
 
     'selected_projection_db' => {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_sel_proj_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_sel_proj_'.$self->o('release_number'),
       -host   => $self->o('selected_projection_db_host'),
       -port   => $self->o('selected_projection_db_port'),
       -user   => $self->o('user'),

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Refseq_import_subpipeline.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Refseq_import_subpipeline.pm
@@ -58,6 +58,7 @@ sub default_options {
 
     'release_number' => '' || $self->o('ensembl_release'),
     'production_name' => '',     # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
 
     'output_path' => '',         # Lustre output dir. This will be the primary dir to house the assembly info and various things from analyses
 
@@ -76,8 +77,8 @@ sub default_options {
     'reference_db_host'   => $self->o('dna_db_host'),
     'reference_db_port'   => $self->o('dna_db_port'),
 
-    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('production_name') . '_pipe_' . $self->o('release_number'),
-    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('production_name') . '_core_' . $self->o('release_number'),
+    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_pipe_' . $self->o('release_number'),
+    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_core_' . $self->o('release_number'),
 
     # This is used for the ensembl_production and the ncbi_taxonomy databases
     'ensembl_release' => $ENV{ENSEMBL_RELEASE},    # this is the current release version on staging to be able to get the correct database
@@ -101,7 +102,7 @@ sub default_options {
     },
 
     'refseq_db' => {
-      -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_refseq_' . $self->o('release_number'),
+      -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_refseq_' . $self->o('release_number'),
       -host   => $self->o('refseq_db_host'),
       -port   => $self->o('refseq_db_port'),
       -user   => $self->o('user'),

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/RepeatMasking.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/RepeatMasking.pm
@@ -43,6 +43,7 @@ sub default_options {
 ########################
     'dbowner' => '' || $ENV{EHIVE_USER} || $ENV{USER},
     'pipeline_name' => '' || $self->o('production_name') . '_' . $self->o('ensembl_release'),
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     'user_r'                           => '',                                  # read only db user
     'user'                             => '',                                  # write db user
     'password'                         => '',                                  # password for write db user
@@ -73,8 +74,8 @@ sub default_options {
 # These values can be replaced in the analysis_base table if they're not known yet
 # If they are not needed (i.e. no projection or rnaseq) then leave them as is
 
-    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('production_name') . '_pipe_' . $self->o('release_number'),
-    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('production_name') . '_core_' . $self->o('release_number'),
+    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_pipe_' . $self->o('release_number'),
+    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_core_' . $self->o('release_number'),
 
     'reference_db_name'   => $self->o('dna_db_name'),
     'reference_db_host'   => $self->o('dna_db_host'),

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/ShortncRNA.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/ShortncRNA.pm
@@ -58,6 +58,7 @@ sub default_options {
     release_number            => '' || $self->o('ensembl_release'),
     species_name              => '', # e.g. mus_musculus
     production_name           => '', # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     taxon_id                  => '', # should be in the assembly report file
     uniprot_set               => '', # e.g. mammals_basic, check UniProtCladeDownloadStatic.pm module in hive config dir for suitable set,
     sanity_set                => '', # sanity checks
@@ -88,12 +89,12 @@ sub default_options {
 ########################
 # Pipe and ref db info
 ########################
-    pipe_db_name                  => $self->o('dbowner').'_'.$self->o('production_name').'_pipe_'.$self->o('release_number'),
-    dna_db_name                   => $self->o('dbowner').'_'.$self->o('production_name').'_core_'.$self->o('release_number'),
+    pipe_db_name                  => $self->o('dbowner').'_'.$self->o('dbname_accession').'_pipe_'.$self->o('release_number'),
+    dna_db_name                   => $self->o('dbowner').'_'.$self->o('dbname_accession').'_core_'.$self->o('release_number'),
 
     ncrna_db_host                => $self->o('databases_host'),
     ncrna_db_port                => $self->o('databases_port'),
-    ncrna_db_name                  => $self->o('dbowner').'_'.$self->o('production_name').'_ncrna_'.$self->o('release_number'),
+    ncrna_db_name                  => $self->o('dbowner').'_'.$self->o('dbname_accession').'_ncrna_'.$self->o('release_number'),
 
     # This is used for the ensembl_production and the ncbi_taxonomy databases
     ensembl_release              => $ENV{ENSEMBL_RELEASE}, # this is the current release version on staging to be able to get the correct database

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/StarScallopRnaseq.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/StarScallopRnaseq.pm
@@ -71,6 +71,7 @@ sub default_options {
     'protein_entry_loc_file' => 'entry_loc',
     'species_name'        => '',                                                                                      # e.g. mus_musculus
     'production_name'     => '',                                                                                      # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     'taxon_id'            => '',                                                                                      # should be in the assembly report file
     'genus_taxon_id'      => $self->o('taxon_id'),
     'sanity_set'          => '',
@@ -89,8 +90,8 @@ sub default_options {
 # Pipe and ref db info
 ########################
 
-    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('production_name') . '_scallop_pipe_' . $self->o('release_number'),
-    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('production_name') . '_core_' . $self->o('release_number'),
+    'pipe_db_name' => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_scallop_pipe_' . $self->o('release_number'),
+    'dna_db_name'  => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_core_' . $self->o('release_number'),
 
     'reference_db_name'   => $self->o('dna_db_name'),
     'reference_db_host'   => $self->o('dna_db_host'),
@@ -98,11 +99,11 @@ sub default_options {
 
     'rnaseq_for_layer_db_host'   => $self->o('databases_host'),
     'rnaseq_for_layer_db_port'   => $self->o('databases_port'),
-    'rnaseq_for_layer_db_name'   => $self->o('dbowner') . '_' . $self->o('production_name') . '_star_rs_layer_' . $self->o('release_number'),
+    'rnaseq_for_layer_db_name'   => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_star_rs_layer_' . $self->o('release_number'),
 
     'rnaseq_for_layer_nr_db_host'   => $self->o('databases_host'),
     'rnaseq_for_layer_nr_db_port'   => $self->o('databases_port'),
-    'rnaseq_for_layer_nr_db_name'   => $self->o('dbowner') . '_' . $self->o('production_name') . '_star_rs_layer_nr_' . $self->o('release_number'),
+    'rnaseq_for_layer_nr_db_name'   => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_star_rs_layer_nr_' . $self->o('release_number'),
 
     'scallop_initial_db_host'   => $self->o('databases_host'),
     'scallop_initial_db_port'   => $self->o('databases_port'),
@@ -112,7 +113,7 @@ sub default_options {
     
     'pcp_db_host' => $self->o('databases_host'),
     'pcp_db_port' => $self->o('databases_port'),
-    'pcp_db_name' => $self->o('dbowner').'_'.$self->o('production_name').'_pcp_'.$self->o('release_number'),
+    'pcp_db_name' => $self->o('dbowner').'_'.$self->o('dbname_accession').'_pcp_'.$self->o('release_number'),
 
     # This is used for the ensembl_production and the ncbi_taxonomy databases
     'ensembl_release' => $ENV{ENSEMBL_RELEASE},    # this is the current release version on staging to be able to get the correct database
@@ -237,7 +238,7 @@ sub default_options {
     },
 
     'scallop_initial_db' => {
-      -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_scallop_initial_' . $self->o('release_number'),
+      -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_scallop_initial_' . $self->o('release_number'),
       -host   => $self->o('scallop_initial_db_host'),
       -port   => $self->o('scallop_initial_db_port'),
       -user   => $self->o('user'),
@@ -246,7 +247,7 @@ sub default_options {
     },
 
     'scallop_blast_db' => {
-      -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_scallop_blast_' . $self->o('release_number'),
+      -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_scallop_blast_' . $self->o('release_number'),
       -host   => $self->o('scallop_blast_db_host'),
       -port   => $self->o('scallop_blast_db_port'),
       -user   => $self->o('user'),
@@ -255,7 +256,7 @@ sub default_options {
     },
 
     'pcp_db'=> {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_pcp_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_pcp_'.$self->o('release_number'),
       -host   => $self->o('pcp_db_host'),
       -port   => $self->o('pcp_db_port'),
       -user   => $self->o('user'),
@@ -264,7 +265,7 @@ sub default_options {
     },
 
     'pcp_nr_db'=> {
-      -dbname => $self->o('dbowner').'_'.$self->o('production_name').'_pcp_nr_'.$self->o('release_number'),
+      -dbname => $self->o('dbowner').'_'.$self->o('dbname_accession').'_pcp_nr_'.$self->o('release_number'),
       -host   => $self->o('pcp_db_host'),
       -port   => $self->o('pcp_db_port'),
       -user   => $self->o('user'),

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/TranscriptSelection.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/TranscriptSelection.pm
@@ -56,6 +56,7 @@ sub default_options {
     'release_number'            => '' || $self->o('ensembl_release'),
     'species_name'              => '',                                                          # e.g. mus_musculus
     'production_name'           => '',                                                          # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     'uniprot_set'               => '',                                                          # e.g. mammals_basic, check UniProtCladeDownloadStatic.pm module in hive config dir for suitable set,
     'sanity_set'                => '',                                                          # sanity checks
     'output_path'               => '',                                                          # Lustre output dir. This will be the primary dir to house the assembly info and various things from analyses
@@ -140,7 +141,7 @@ sub default_options {
 
     'ncrna_db_host'   => $self->o('databases_host'),
     'ncrna_db_port'   => $self->o('databases_port'),
-    ncrna_db_name     => $self->o('dbowner') . '_' . $self->o('production_name') . '_ncrna_' . $self->o('release_number'),
+    ncrna_db_name     => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_ncrna_' . $self->o('release_number'),
     'ncrna_db_user'   => $self->o('user'),
     'ncrna_db_pass'   => $self->o('password'),
 
@@ -238,20 +239,20 @@ sub default_options {
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 #
 
-    cdna_db_name => $self->o('dbowner') . '_' . $self->o('production_name') . '_cdna_' . $self->o('release_number'),
-    genblast_nr_db_name => $self->o('dbowner').'_'.$self->o('production_name').'_genblast_nr_'.$self->o('release_number'),
-    genblast_rnaseq_support_nr_db_name => $self->o('dbowner').'_'.$self->o('production_name').'_gb_rnaseq_nr_'.$self->o('release_number'),
-    ig_tr_db_name => $self->o('dbowner').'_'.$self->o('production_name').'_igtr_'.$self->o('release_number'),
-    best_targeted_db_name => $self->o('dbowner').'_'.$self->o('production_name').'_bt_'.$self->o('release_number'),
-    long_read_final_db_name => $self->o('dbowner') . '_' . $self->o('production_name') . '_lrfinal_' . $self->o('release_number'),
-    selected_projection_db_name => $self->o('dbowner') . '_' . $self->o('production_name') . '_sel_proj_' . $self->o('release_number'),
-    rnaseq_for_layer_db_name => $self->o('dbowner') . '_' . $self->o('production_name') . '_rnalayer_nr_' . $self->o('release_number'),
-    rnaseq_for_layer_nr_db_name => $self->o('dbowner').'_'.$self->o('production_name').'_rnalayer_nr_'.$self->o('release_number'),
-    layering_db_name => $self->o('dbowner') . '_' . $self->o('production_name') . '_layer_' . $self->o('release_number'),
-    utr_db_name => $self->o('dbowner') . '_' . $self->o('production_name') . '_utr_' . $self->o('release_number'),
-    genebuilder_db_name => $self->o('dbowner') . '_' . $self->o('production_name') . '_gbuild_' . $self->o('release_number'),
-    pseudogene_db_name => $self->o('dbowner') . '_' . $self->o('production_name') . '_pseudo_' . $self->o('release_number'),
-    final_geneset_db_name => $self->o('dbowner') . '_' . $self->o('production_name') . '_final_' . $self->o('release_number'),
+    cdna_db_name => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_cdna_' . $self->o('release_number'),
+    genblast_nr_db_name => $self->o('dbowner').'_'.$self->o('dbname_accession').'_genblast_nr_'.$self->o('release_number'),
+    genblast_rnaseq_support_nr_db_name => $self->o('dbowner').'_'.$self->o('dbname_accession').'_gb_rnaseq_nr_'.$self->o('release_number'),
+    ig_tr_db_name => $self->o('dbowner').'_'.$self->o('dbname_accession').'_igtr_'.$self->o('release_number'),
+    best_targeted_db_name => $self->o('dbowner').'_'.$self->o('dbname_accession').'_bt_'.$self->o('release_number'),
+    long_read_final_db_name => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_lrfinal_' . $self->o('release_number'),
+    selected_projection_db_name => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_sel_proj_' . $self->o('release_number'),
+    rnaseq_for_layer_db_name => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_rnalayer_nr_' . $self->o('release_number'),
+    rnaseq_for_layer_nr_db_name => $self->o('dbowner').'_'.$self->o('dbname_accession').'_rnalayer_nr_'.$self->o('release_number'),
+    layering_db_name => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_layer_' . $self->o('release_number'),
+    utr_db_name => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_utr_' . $self->o('release_number'),
+    genebuilder_db_name => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_gbuild_' . $self->o('release_number'),
+    pseudogene_db_name => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_pseudo_' . $self->o('release_number'),
+    final_geneset_db_name => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_final_' . $self->o('release_number'),
 
 ########################
 # db info

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/long_read.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/long_read.pm
@@ -60,6 +60,7 @@ sub default_options {
     'release_number' => '' || $self->o('ensembl_release'),
     'species_name'    => '',                                                                                                          # e.g. mus_musculus
     'production_name' => '',                                                                                                          # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     'output_path'     => '',                                                                                                          # Lustre output dir. This will be the primary dir to house the assembly info and various things from analyses
     'uniprot_version' => 'uniprot_2021_04',                                                                                           # What UniProt data dir to use for various analyses
 
@@ -143,7 +144,7 @@ sub default_options {
     # db info
     ########################
     long_read_initial_db => {
-      -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_lrinitial_' . $self->o('release_number'),
+      -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_lrinitial_' . $self->o('release_number'),
       -host   => $self->o('long_read_initial_db_host'),
       -port   => $self->o('long_read_initial_db_port'),
       -user   => $self->o('user'),
@@ -152,7 +153,7 @@ sub default_options {
     },
 
     long_read_collapse_db => {
-      -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_lrcollapse_' . $self->o('release_number'),
+      -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_lrcollapse_' . $self->o('release_number'),
       -host   => $self->o('long_read_collapse_db_host'),
       -port   => $self->o('long_read_collapse_db_port'),
       -user   => $self->o('user'),
@@ -161,7 +162,7 @@ sub default_options {
     },
 
     long_read_final_db => {
-      -dbname => $self->o('dbowner') . '_' . $self->o('production_name') . '_lrfinal_' . $self->o('release_number'),
+      -dbname => $self->o('dbowner') . '_' . $self->o('dbname_accession') . '_lrfinal_' . $self->o('release_number'),
       -host   => $self->o('long_read_final_db_host'),
       -port   => $self->o('long_read_final_db_port'),
       -user   => $self->o('user'),

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/production_rnaseq_db.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/production_rnaseq_db.pm
@@ -61,6 +61,7 @@ sub default_options {
     'release_number'            => '' || $self->o('ensembl_release'),
     'species_name'              => '', # e.g. mus_musculus
     'production_name'           => '', # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
+    dbname_accession          => '', # This is the assembly accession without [._] and all lower case, i.e gca001857705v1
     'taxon_id'                  => '', # should be in the assembly report file
     'output_path'               => '', # Lustre output dir. This will be the primary dir to house the assembly info and various things from analyses
     'assembly_name'             => '', # Name (as it appears in the assembly report file)
@@ -79,15 +80,15 @@ sub default_options {
     ########################
     'rnaseq_db_host'               => $self->o('databases_host'),
     'rnaseq_db_port'               => $self->o('databases_port'),
-    'rnaseq_db_name'               => $self->o('dbowner').'_'.$self->o('production_name').'_rnaseq_'.$self->o('release_number'),
+    'rnaseq_db_name'               => $self->o('dbowner').'_'.$self->o('dbname_accession').'_rnaseq_'.$self->o('release_number'),
 
     'rnaseq_refine_db_host'         => $self->o('databases_host'),
     'rnaseq_refine_db_port'         => $self->o('databases_port'),
-    'rnaseq_refine_db_name'         => $self->o('dbowner').'_'.$self->o('production_name').'_refine_'.$self->o('release_number'),
+    'rnaseq_refine_db_name'         => $self->o('dbowner').'_'.$self->o('dbname_accession').'_refine_'.$self->o('release_number'),
 
     'rnaseq_blast_db_host'         => $self->o('databases_host'),
     'rnaseq_blast_db_port'         => $self->o('databases_port'),
-    'rnaseq_blast_db_name'         => $self->o('dbowner').'_'.$self->o('production_name').'_scallop_blast_'.$self->o('release_number'),
+    'rnaseq_blast_db_name'         => $self->o('dbowner').'_'.$self->o('dbname_accession').'_scallop_blast_'.$self->o('release_number'),
 
     # This is used for the ensembl_production and the ncbi_taxonomy databases
     'ensembl_release'              => $ENV{ENSEMBL_RELEASE}, # this is the current release version on staging to be able to get the correct database

--- a/modules/t/test-genome-DBs/pararge_aegeria/core/attrib_type.txt
+++ b/modules/t/test-genome-DBs/pararge_aegeria/core/attrib_type.txt
@@ -1,2 +1,3 @@
 6	toplevel	Top Level	Top Level Non-Redundant Sequence Region
 367	karyotype_rank	Rank in the karyotype	For a given seq_region, if it is part of the species karyotype, will indicate its rank
+554	is_canonical	Ensembl Canonical	This transcript is the chosen canonical for its gene. For protein-coding genes, this is the MANE_Select transcript if there is one. If not, the canonical transcript is chosen by a pipeline that takes into account several criteria including transcript support (TSL), functional importance (APPRIS), representation in RefSeq and UniProt databases, length and coverage of pathogenic variants, where available. For non protein-coding genes, it is usually the longest transcript with the same biotype as its parent gene.

--- a/scripts/genebuild/create_annotation_configs.pl
+++ b/scripts/genebuild/create_annotation_configs.pl
@@ -455,6 +455,7 @@ sub parse_assembly_report {
   }
 
 # create production name - must be unique, no more than trinomial, and include GCA
+# Add dbname_accession which replace production_name in the dbname and is just the GCA MySQL friendly
   my $underscore_count = $species_name =~ tr/_//;
   $species_name =~ /(^[^_]+_[^_]+)_*.*/;
   my $binomial_name = $1;
@@ -462,6 +463,7 @@ sub parse_assembly_report {
   $accession_append =~ s/\./v/g;
   $accession_append =~ s/_//g;
   $assembly_hash->{'production_name'} = $binomial_name.'_'.$accession_append;
+  $assembly_hash->{'dbname_accession'} = $accession_append;
 
   $assembly_hash->{'strain'} = $species_name;
   $assembly_hash->{'assembly_level'} = $assembly_level;


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
New feature

_Include a short description_
To avoid database names longer than 64 characters we are using the gca only instead of the production name which is the gca and the scientific name. The pipeline name in guiHive still uses the production name

_Include links to JIRA tickets_
NA
# Testing
_Have you tested it?_
Yes but only with two sub pipelines

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
