### PR TITLE
bugfix: check for 'alarm clock restart' if timer is set

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveWGA2GenesDirect.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveWGA2GenesDirect.pm
@@ -195,7 +195,7 @@ sub run {
      my $successfully_projected = 0;
      my $preliminary_transcripts = [];
      eval {
-      local $SIG{ALRM} = sub { die "alarm clock restart" };
+      local $SIG{ALRM} = sub { die "alarm clock restart\n" };
       alarm $timer; #schedule alarm in '$timer' seconds
 
       foreach my $chain (@{$source_transcript->{_genomic_align_block_chains}}) {
@@ -239,7 +239,7 @@ sub run {
       alarm 0; #reset alarm
     }; # end eval
 
-    if($@ && $@ !~ /alarm clock restart/) {
+    if($@ && $@ eq "alarm clock restart\n") {
       say "Projection failed for transcript ".$source_transcript->dbID." because of time limit on timer param";
     }
 


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
Fix
_Include a short description_
The alarm code was triggered if the error message didn't have the "passphrase". It now correctly check that the "passphrase" is present to throw when the timer expired
_Include links to JIRA tickets_
NA
# Testing
_Have you tested it?_
yes
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
