### PR TITLE
Feature/repeat masker meta keys

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/BestTargetted_subpipeline.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/BestTargetted_subpipeline.pm
@@ -64,7 +64,7 @@ sub default_options {
 
     'taxon_id'    => '',         # should be in the assembly report file
     use_genome_flatfile => 1,
-    wide_repeat_logic_names => [],
+    repeat_logic_names => [],
 
     'output_path'   => '',                                               # Lustre output dir. This will be the primary dir to house the assembly info and various things from analyses
     targetted_path  => catdir( $self->o('output_path'), 'targetted' ),
@@ -212,7 +212,7 @@ sub pipeline_wide_parameters {
     %{$self->SUPER::pipeline_wide_parameters},
     use_genome_flatfile => $self->o('use_genome_flatfile'),
     genome_file => $self->o('faidx_genome_file'),
-    wide_repeat_logic_names => $self->o('wide_repeat_logic_names'),
+    wide_repeat_logic_names => $self->o('repeat_logic_names'),
   }
 }
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -85,8 +85,6 @@ sub default_options {
 
     repbase_logic_name               => '', # repbase logic name i.e. repeatmask_repbase_XXXX, ONLY FILL THE XXXX BIT HERE!!! e.g primates
     repbase_library                  => '', # repbase library name, this is the actual repeat repbase library to use, e.g. "Mus musculus"
-    replace_repbase_with_red_to_mask => '0', # Setting this will replace 'full_repbase_logic_name' with 'red_logic_name' repeat features in the masking process
-    use_repeatmodeler_to_mask        => '0', # Setting this will include the repeatmodeler library in the masking process
     repeatmodeler_library            => '', # This should be the path to a custom repeat library, leave blank if none exists
 
     stable_id_start                  => '0', # When mapping is not required this is usually set to 0
@@ -255,6 +253,9 @@ sub default_options {
     full_repbase_logic_name  => "repeatmask_repbase_".$self->o('repbase_logic_name'),
     red_logic_name           => 'repeatdetector', # logic name for the Red repeat finding analysis
     repeatmodeler_logic_name => 'repeatmask_repeatmodeler',
+    first_choice_repeat => $self->o('full_repbase_logic_name'),
+    second_choice_repeat => $self->o('repeatmodeler_logic_name'),
+    third_choice_repeat => $self->o('red_logic_name'),
 
     ensembl_analysis_script => catdir($self->o('enscode_root_dir'), 'ensembl-analysis', 'scripts'),
     loading_report_script   => catfile($self->o('ensembl_analysis_script'), 'genebuild', 'report_genome_prep_stats.pl'),
@@ -526,16 +527,6 @@ sub pipeline_create_commands {
 sub pipeline_wide_parameters {
   my ($self) = @_;
 
-  # set the logic names for repeat masking
-  my $wide_repeat_logic_names;
-  if ($self->o('use_repeatmodeler_to_mask')) {
-    $wide_repeat_logic_names = [$self->o('full_repbase_logic_name'),$self->o('repeatmodeler_logic_name'),'dust'];
-  } elsif ($self->o('replace_repbase_with_red_to_mask')) {
-    $wide_repeat_logic_names = [$self->o('red_logic_name'),'dust'];
-  } else {
-    $wide_repeat_logic_names = [$self->o('full_repbase_logic_name'),'dust'];
-  }
-
   return {
     %{$self->SUPER::pipeline_wide_parameters},
     skip_projection => $self->o('skip_projection'),
@@ -544,10 +535,7 @@ sub pipeline_wide_parameters {
     skip_long_read => $self->o('skip_long_read'),
     skip_lastz => $self->o('skip_lastz'),
     skip_repeatmodeler => $self->o('skip_repeatmodeler'),
-    wide_repeat_logic_names => $wide_repeat_logic_names,
     skip_post_repeat_analyses => $self->o('skip_post_repeat_analyses'),	
-    repeatmasker_slice_size   => $self->o('repeatmasker_slice_size'),
-    batch_target_size => $self->o('batch_target_size'),
   }
 }
 
@@ -785,7 +773,6 @@ sub pipeline_analyses {
           user_r => $self->o('user_r'),
           dna_db_host => $self->o('dna_db_host'),
           dna_db_port => $self->o('dna_db_port'),
-          repbase_logic_name => $self->o('repbase_logic_name'),
           release_number => $self->o('release_number'),
           species_name => $self->o('species_name'),
           production_name => $self->o('production_name'),
@@ -798,8 +785,6 @@ sub pipeline_analyses {
           species_url => $self->o('species_url'),
           load_toplevel_only => $self->o('load_toplevel_only'),
           custom_toplevel_file_path => $self->o('custom_toplevel_file_path'),
-          use_repeatmodeler_to_mask => $self->o('use_repeatmodeler_to_mask'),
-          replace_repbase_with_red_to_mask => $self->o('replace_repbase_with_red_to_mask'),
         },
       },
       -rc_name      => 'default',
@@ -949,10 +934,8 @@ sub pipeline_analyses {
           species_name => $self->o('species_name'),
           use_genome_flatfile => $self->o('use_genome_flatfile'),
           skip_repeatmodeler => $self->o('skip_repeatmodeler'),
-          replace_repbase_with_red_to_mask => $self->o('replace_repbase_with_red_to_mask'),
           red_logic_name => $self->o('red_logic_name'),
           repeatmodeler_library => $self->o('repeatmodeler_library'),
-          use_repeatmodeler_to_mask => $self->o('use_repeatmodeler_to_mask'),
 	  skip_post_repeat_analyses => $self->o('skip_post_repeat_analyses'),
 	  batch_target_size => $self->o('batch_target_size'),
 	  repeatmasker_slice_size => $self->o('repeatmasker_slice_size'),

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -1445,7 +1445,7 @@ sub pipeline_analyses {
           dbname_accession => $self->o('dbname_accession'),
           species_name => $self->o('species_name'),
           taxon_id => $self->o('taxon_id'),
-          wide_repeat_logic_names => '#wide_repeat_logic_names#',
+          repeat_logic_names => [$self->o('first_choice_repeat'), 'dust'],
           transcript_selection_url => $transcript_selection_pipe_url,
           use_genome_flatfile => $self->o('use_genome_flatfile'),
         },

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Genome_annotation_conf.pm
@@ -1153,38 +1153,38 @@ sub pipeline_analyses {
       },
       -rc_name => 'default',
       -flow_into => {
-        1 =>['repeat_masker_coverage'],
+        1 =>['create_repeatmasking_coverage_jobs'],
       },
     },
 
 
     {
-      -logic_name => 'repeat_masker_coverage',
+      -logic_name => 'create_repeatmasking_coverage_jobs',
+      -module => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+      -parameters => {
+        column_names => ['repeat_logic_name', 'assembly_name'],
+        inputlist => [[$self->o('first_choice_repeat'), '#assembly_name#'], [$self->o('second_choice_repeat'), '#assembly_name#'], [$self->o('third_choice_repeat'), '#assembly_name#']],
+      },
+      -rc_name => 'default',
+      -max_retry_count => 0,
+      -flow_into => {
+        2 => ['repeatmasking_coverage'],
+      }
+    },
+
+
+    {
+      -logic_name => 'repeatmasking_coverage',
       -module => 'Bio::EnsEMBL::Analysis::Hive::RunnableDB::HiveRepeatCoverage',
       -parameters => {
         source_db => $self->o('reference_db'),
-        repeat_logic_names => '#wide_repeat_logic_names#',
+        repeat_logic_names => ['#repeat_logic_name#', 'dust'],
         coord_system_version => '#assembly_name#',
         email => $self->o('email_address'),
       },
       -rc_name => '10GB',
-      -flow_into => {
-        1 =>['repeatmodeler_coverage'],
-      },
     },
 
-
-    {
-      -logic_name => 'repeatmodeler_coverage',
-      -module => 'Bio::EnsEMBL::Analysis::Hive::RunnableDB::HiveRepeatCoverage',
-      -parameters => {
-        source_db => $self->o('reference_db'),
-        repeat_logic_names => [$self->o('repeatmodeler_logic_name')],
-        coord_system_version => '#assembly_name#',
-        email => $self->o('email_address'),
-      },
-      -rc_name => '4GB',
-    },
 
     {
       -logic_name => 'skip_lastz',

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/LoadAssembly.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/LoadAssembly.pm
@@ -49,7 +49,6 @@ sub default_options {
     dna_db_host               => '', # host for dna db
     pipe_db_port              => '', # port for pipeline host
     dna_db_port               => '', # port for dna db host
-    repbase_logic_name        => '', # repbase logic name i.e. repeatmask_repbase_XXXX, ONLY FILL THE XXXX BIT HERE!!! e.g primates
     release_number            => '' || $self->o('ensembl_release'),
     species_name              => '', # e.g. mus_musculus
     production_name           => '', # usually the same as species name but currently needs to be a unique entry for the production db, used in all core-like db names
@@ -66,10 +65,7 @@ sub default_options {
     # Keys for custom loading, only set/modify if that's what you're doing
     load_toplevel_only        => '1', # This will not load the assembly info and will instead take any chromosomes, unplaced and unlocalised scaffolds directly in the DNA table
     custom_toplevel_file_path => '', # Only set this if you are loading a custom toplevel, requires load_toplevel_only to also be set to 2
-    use_repeatmodeler_to_mask => '0', # Setting this will include the repeatmodeler library in the masking process
 
-    red_logic_name                   => 'repeatdetector', # logic name for the Red repeat finding analysis
-    replace_repbase_with_red_to_mask => '0', # Setting this will replace 'full_repbase_logic_name' with 'red_logic_name' repeat features in the masking process
 
     # The following might not be known in advance, since the come from other pipelines
     # These values can be replaced in the analysis_base table if they're not known yet
@@ -115,8 +111,6 @@ sub default_options {
     primary_assembly_dir_name => 'Primary_Assembly',
     contigs_source            => 'ena',
 
-    full_repbase_logic_name  => "repeatmask_repbase_".$self->o('repbase_logic_name'),
-    repeatmodeler_logic_name => 'repeatmask_repeatmodeler',
 
     ensembl_analysis_script => catdir($self->o('enscode_root_dir'), 'ensembl-analysis', 'scripts'),
     sequence_dump_script    => catfile($self->o('ensembl_analysis_script'), 'sequence_dump.pl'),
@@ -337,12 +331,7 @@ sub pipeline_analyses {
           '(1, "assembly.provider_url", "'.$self->o('assembly_provider_url').'"),'.
           '(1, "annotation.provider_name", "'.$self->o('annotation_provider_name').'"),'.
           '(1, "annotation.provider_url", "'.$self->o('annotation_provider_url').'"),'.
-          '(1, "species.production_name", "'.$self->o('production_name').'"),'.
-          ($self->o('replace_repbase_with_red_to_mask') ? '(1, "repeat.analysis", "'.$self->o('red_logic_name').'"),' :
-            '(1, "repeat.analysis", "'.$self->o('full_repbase_logic_name').'"),').
-          ($self->o('use_repeatmodeler_to_mask') ? '(1, "repeat.analysis", "'.$self->o('repeatmodeler_logic_name').'"),': '').
-          '(1, "repeat.analysis", "dust"),'.
-          '(1, "repeat.analysis", "trf")',
+          '(1, "species.production_name", "'.$self->o('production_name').'")',
         ],
       },
       -rc_name    => 'default',
@@ -474,7 +463,6 @@ sub pipeline_analyses {
           'assembly.provider_url' => $self->o('assembly_provider_url'),
           'annotation.provider_name' => $self->o('annotation_provider_name'),
           'annotation.provider_url' => $self->o('annotation_provider_url'),
-          'repeat.analysis' => [$self->o('full_repbase_logic_name'), 'dust', 'trf'],
           'species.production_name' => $self->o('production_name'),
           'species.taxonomy_id' => $self->o('taxon_id'),
         }

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/RepeatMasking.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/RepeatMasking.pm
@@ -65,6 +65,9 @@ sub default_options {
     'repeatmodeler_library'            => '',                                  # This should be the path to a custom repeat library, leave blank if none exists
     'use_repeatmodeler_to_mask'        => '0',                                 # Setting this will include the repeatmodeler library in the masking process
     'skip_post_repeat_analyses'        => '0',
+    first_choice_repeat => $self->o('full_repbase_logic_name'),
+    second_choice_repeat => $self->o('repeatmodeler_logic_name'),
+    third_choice_repeat => $self->o('red_logic_name'),
 	
 ########################
     # Pipe and ref db info
@@ -155,20 +158,9 @@ sub default_options {
 sub pipeline_wide_parameters {
   my ($self) = @_;
 
-  # set the logic names for repeat masking
-  my $wide_repeat_logic_names;
-  if ( $self->o('use_repeatmodeler_to_mask') and $self->o('use_repeatmodeler_to_mask') !~ /^#:subst/) {
-    $wide_repeat_logic_names = [ $self->o('full_repbase_logic_name'), $self->o('repeatmodeler_logic_name'), 'dust' ];
-  } elsif ( $self->o('replace_repbase_with_red_to_mask') and $self->o('replace_repbase_with_red_to_mask') !~ /^#:subst/) {
-    $wide_repeat_logic_names = [ $self->o('red_logic_name'), 'dust' ];
-  } else {
-    $wide_repeat_logic_names = [ $self->o('full_repbase_logic_name'), 'dust' ];
-  }
-
   return {
     %{ $self->SUPER::pipeline_wide_parameters },
     skip_repeatmodeler      => $self->o('skip_repeatmodeler'),
-    wide_repeat_logic_names => $wide_repeat_logic_names,
     use_genome_flatfile     => $self->o('use_genome_flatfile'),
     genome_file             => $self->o('faidx_genome_file'),
     skip_post_repeat_analyses => $self->o('skip_post_repeat_analyses'),	
@@ -218,7 +210,7 @@ sub pipeline_analyses {
       -input_ids  => [{}],
       -flow_into => {
         '2->A' => ['semaphore_10mb_slices'],
-        'A->1' => ['dump_softmasked_toplevel'],
+        'A->1' => ['insert_fixed_repeat_analysis_meta_key_jobs'],
         1 => ['repeatdetector'],
       },
     },
@@ -397,6 +389,106 @@ sub pipeline_analyses {
     },
 
     {
+      -logic_name => 'insert_fixed_repeat_analysis_meta_key_jobs',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::JobFactory',
+      -rc_name    => 'default',
+      -parameters => {
+        inputlist => ['dust', 'trf'],
+        column_names => ['repeat_logic_name'],
+      },
+      -flow_into => {
+        '2->A' => ['check_fixed_repeat_analysis_meta_key'],
+        '1->A' => ['check_first_choice_repeat_present'],
+        'A->1' => ['dump_softmasked_toplevel'],
+      },
+    },
+
+    {
+      -logic_name => 'check_fixed_repeat_analysis_meta_key',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -rc_name    => 'default',
+      -parameters => {
+        cmd => q(if [[ `mysql -h #reference_db_host# -P #reference_db_port# -u #user_r# #reference_db_name# -NB -e "SELECT COUNT(*) FROM repeat_feature JOIN analysis USING(analysis_id) WHERE logic_name = '#repeat_logic_name#'"` -eq 0 ]]; then exit 42; fi),
+        reference_db_host => $self->o('reference_db_host'),
+        reference_db_port => $self->o('reference_db_port'),
+        reference_db_name => $self->o('reference_db_name'),
+        user_r => $self->o('user_r'),
+        return_codes_2_branches => {42 => 2},
+      },
+      -flow_into => {
+        1 => ['insert_repeat_analysis_meta_key'],
+      },
+    },
+
+    {
+      -logic_name => 'check_first_choice_repeat_present',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -rc_name    => 'default',
+      -parameters => {
+        cmd => q(if [[ `mysql -h #reference_db_host# -P #reference_db_port# -u #user_r# #reference_db_name# -NB -e "SELECT COUNT(*) FROM repeat_feature JOIN analysis USING(analysis_id) WHERE logic_name = '#repeat_logic_name#'"` -eq 0 ]]; then exit 42; fi),
+        repeat_logic_name => $self->o('first_choice_repeat'),
+        reference_db_host => $self->o('reference_db_host'),
+        reference_db_port => $self->o('reference_db_port'),
+        reference_db_name => $self->o('reference_db_name'),
+        user_r => $self->o('user_r'),
+        return_codes_2_branches => {42 => 2},
+      },
+      -flow_into => {
+        1 => {'insert_repeat_analysis_meta_key' => {repeat_logic_name => '#repeat_logic_name#'}},
+        2 => ['check_second_choice_repeat_present'],
+      },
+    },
+
+    {
+      -logic_name => 'check_second_choice_repeat_present',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -rc_name    => 'default',
+      -parameters => {
+        cmd => q(if [[ `mysql -h #reference_db_host# -P #reference_db_port# -u #user_r# #reference_db_name# -NB -e "SELECT COUNT(*) FROM repeat_feature JOIN analysis USING(analysis_id) WHERE logic_name = '#repeat_logic_name#'"` -eq 0 ]]; then exit 42; fi),
+        repeat_logic_name => $self->o('second_choice_repeat'),
+        reference_db_host => $self->o('reference_db_host'),
+        reference_db_port => $self->o('reference_db_port'),
+        reference_db_name => $self->o('reference_db_name'),
+        user_r => $self->o('user_r'),
+        return_codes_2_branches => {42 => 2},
+      },
+      -flow_into => {
+        1 => {'insert_repeat_analysis_meta_key' => {repeat_logic_name => '#repeat_logic_name#'}},
+        2 => ['check_third_choice_repeat_present'],
+      },
+    },
+
+    {
+      -logic_name => 'check_third_choice_repeat_present',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
+      -rc_name    => 'default',
+      -parameters => {
+        cmd => q(if [[ `mysql -h #reference_db_host# -P #reference_db_port# -u #user_r# #reference_db_name# -NB -e "SELECT COUNT(*) FROM repeat_feature JOIN analysis USING(analysis_id) WHERE logic_name = '#repeat_logic_name#'"` -eq 0 ]]; then exit 42; fi),
+        repeat_logic_name => $self->o('third_choice_repeat'),
+        reference_db_host => $self->o('reference_db_host'),
+        reference_db_port => $self->o('reference_db_port'),
+        reference_db_name => $self->o('reference_db_name'),
+        user_r => $self->o('user_r'),
+        return_codes_2_branches => {42 => 2},
+      },
+      -flow_into => {
+        1 => {'insert_repeat_analysis_meta_key' => {repeat_logic_name => '#repeat_logic_name#'}},
+      },
+    },
+
+    {
+      -logic_name => 'insert_repeat_analysis_meta_key',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SqlCmd',
+      -parameters => {
+        db_conn => $self->o('reference_db'),
+        sql => [
+          'INSERT INTO meta (species_id,meta_key,meta_value) VALUES (1,"repeat.analysis","#repeat_logic_name#")',
+        ],
+      },
+      -rc_name    => 'default',
+    },
+
+    {
       # Set the toplevel
       -logic_name => 'dump_softmasked_toplevel',
       -module     => 'Bio::EnsEMBL::Analysis::Hive::RunnableDB::HiveDumpGenome',
@@ -406,7 +498,7 @@ sub pipeline_analyses {
         'output_path'        => $self->o('genome_dumps'),
         'enscode_root_dir'   => $self->o('enscode_root_dir'),
         'species_name'       => $self->o('species_name'),
-        'repeat_logic_names' => '#wide_repeat_logic_names#',
+        mask                 => 1,
       },
       -flow_into => {
         1 => ['format_softmasked_toplevel'],

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDumpGenome.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveDumpGenome.pm
@@ -47,10 +47,12 @@ sub param_defaults {
 
   return {
     %{$self->SUPER::param_defaults},
+    repeat_logic_names => [],
     alt_as_scaffolds => 0,
     patch_only => 0,
     lfs_stripe => 0,
     lfs_options => undef,
+    mask => 0,
   }
 }
 
@@ -103,6 +105,11 @@ sub fetch_input {
   unless($self->param('enscode_root_dir')) {
     $self->throw("enscode_dir not passed into parameters hash. You need to specify where your code checkout is");
   }
+  if ($self->param('mask') and !@{$self->param('repeat_logic_names')}) {
+    my $db = $self->get_database_by_name('target_db');
+    my @repeat_logic_names = grep {$_ ne 'trf'} @{$db->get_MetaContainer->list_value_by_key('repeat.analysis')};
+    $self->param('repeat_logic_names', \@repeat_logic_names);
+  }
 
   return 1;
 }
@@ -124,15 +131,6 @@ sub run {
   my $self = shift;
 
   my $db_info = $self->param('target_db');
-  my $repeat_logic_names = $self->param('repeat_logic_names');
-  my $repeat_string;
-  if(scalar(@{$repeat_logic_names})) {
-    $repeat_string .= ' -mask -softmask ';
-    foreach my $repeat_logic_name (@{$repeat_logic_names}) {
-      $repeat_string .= ' -mask_repeat '.$repeat_logic_name;
-    }
-  }
-
   my $cmd = 'perl '.catfile($self->param('enscode_root_dir'), 'ensembl-analysis', 'scripts', 'sequence_dump.pl').
             ' -dbuser '.$db_info->{-user}.
             ' -dbport '.$db_info->{-port}.
@@ -144,7 +142,14 @@ sub run {
             ' -nonref'.
             ' -filename '.catfile($self->param('output_path'), $self->param('species_name').'_softmasked_toplevel.fa');
 
-  $cmd .= $repeat_string if ($repeat_string);
+  my $repeat_logic_names = $self->param('repeat_logic_names');
+  if(scalar(@{$repeat_logic_names})) {
+    $cmd .= ' -mask -softmask';
+    foreach my $repeat_logic_name (@{$repeat_logic_names}) {
+      $cmd .= ' -mask_repeat '.$repeat_logic_name;
+    }
+  }
+
   $cmd .= ' -dbpass '.$db_info->{-pass} if ($db_info->{-pass});
   $cmd .= ' -alt_as_scaffolds ' if ($self->param('alt_as_scaffolds'));
 
@@ -152,16 +157,16 @@ sub run {
     $cmd .= " -patch_only ";
   }
 
-  say "Running command:\n".$cmd;
+  $self->say_with_header($cmd);
+  $self->output([$cmd]);
 
-  execute_with_wait($cmd);
 }
 
 
 =head2 write_output
 
  Arg [1]    : None
- Description: Nothing to do store in the database
+ Description: Writing the fasta file
  Returntype : None
  Exceptions : None
 
@@ -170,7 +175,9 @@ sub run {
 sub write_output {
   my $self = shift;
 
-  return 1;
+  foreach my $cmd (@{$self->output}) {
+    execute_with_wait($cmd);
+  }
 }
 
 1;

--- a/scripts/genebuild/create_annotation_configs.pl
+++ b/scripts/genebuild/create_annotation_configs.pl
@@ -129,6 +129,11 @@ while(<IN>) {
 }
 close IN || throw("Could not close $config_file");
 
+# If replace_repbase_with_red_to_mask is true then force first_choice_repeat to be red logic name
+if (exists $general_hash->{'replace_repbase_with_red_to_mask'} and $general_hash->{'replace_repbase_with_red_to_mask'} and !exists $general_hash->{first_choice_repeat}) {
+  $general_hash->{first_choice_repeat} = $general_hash->{red_logic_name} || 'repeatdetector';
+}
+
  my $assembly_registry = new Bio::EnsEMBL::Analysis::Hive::DBSQL::AssemblyRegistryAdaptor(
   -host    => $assembly_registry_host,
   -port    => $assembly_registry_port,


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
New feature
_Include a short description_
The repeatmasker pipeline will add the 'repeat.analysis' meta keys to the core database. New parameters `*_
choice_repeat` to order the repeat analyses to be checked is set. If the parameters `replace_repbase_with_red_to_mask` is set in the ini file, red would be the first choice.
The DumpGenome module can use the 'repeat.analysis' to fetch the correct set is `mask` is set and `repeat_logic_names` is empty
Now all repeat analysis are tested for their coverage.

_Include links to JIRA tickets_
NA
# Testing
_Have you tested it?_
Yes
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
