### PR TITLE
Check repeatmask meta keys

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/RepeatMasking.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/RepeatMasking.pm
@@ -410,7 +410,7 @@ sub pipeline_analyses {
       -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
       -rc_name    => 'default',
       -parameters => {
-        cmd => q(if [[ `mysql -h #reference_db_host# -P #reference_db_port# -u #user_r# #reference_db_name# -NB -e "SELECT COUNT(*) FROM repeat_feature JOIN analysis USING(analysis_id) WHERE logic_name = '#repeat_logic_name#'"` -eq 0 ]]; then exit 42; fi),
+        cmd => q(if [[ `mysql -h #reference_db_host# -P #reference_db_port# -u #user_r# #reference_db_name# -NB -e "SELECT COUNT(*) FROM meta WHERE meta_key = 'repeat.analysis'"` -eq 0 ]]; then exit 42; fi),
         reference_db_host => $self->o('reference_db_host'),
         reference_db_port => $self->o('reference_db_port'),
         reference_db_name => $self->o('reference_db_name'),


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
fix
_Include a short description_
The pipeline fails in adding the repeat masking meta key in insert_repeat_analysis_meta_key because it is duplicated. The meta key is already added in the Red module but  check_fixed_repeat_analysis_meta_key doesn't check the meta table so doesn't see that the meta key is already present. 
The query in check_fixed_repeat_analysis_meta_key now checks the meta table and if the meta key is present will skip the next analysis.
_Include links to JIRA tickets_ table 

# Testing
_Have you tested it?_

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
@EreboPSilva 