### PR TITLE
increased resources in rnaseq_for_layer_sanity_checks_star

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/StarScallopRnaseq.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/StarScallopRnaseq.pm
@@ -904,6 +904,7 @@ sub pipeline_analyses {
         min_allowed_feature_counts => get_analysis_settings( 'Bio::EnsEMBL::Analysis::Hive::Config::SanityChecksStatic',
           'gene_db_checks' )->{ $self->o('sanity_set') }->{'rnaseq_blast'},
       },
+      -rc_name   => '2GB',
       -flow_into => {
         1 => ['create_rnaseq_layer_nr_db_star'],
       },


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
fix
_Include a short description_
The analysis is often failing due to MEMLIMIT, the resources have been increased from default to 2GB
_Include links to JIRA tickets_

# Testing
_Have you tested it?_
yes
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
@ndliberial 