### PR TITLE
Use hive_capacity to restrict worker numbers to avoid database overload

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/BestTargetted_subpipeline.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/BestTargetted_subpipeline.pm
@@ -323,6 +323,7 @@ sub pipeline_analyses {
         calculate_coverage_and_pid => $self->o('target_exonerate_calculate_coverage_and_pid'),
       },
       -rc_name => '3GB',
+      -hive_capacity => $self->o('hc_normal'),
       -flow_into => {
         -1 => ['targetted_exonerate_retry'],
       },
@@ -343,6 +344,7 @@ sub pipeline_analyses {
         calculate_coverage_and_pid => $self->o('target_exonerate_calculate_coverage_and_pid'),
       },
       -rc_name => '10GB',
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {
@@ -391,6 +393,7 @@ sub pipeline_analyses {
         OPTIONS           => '-T 20',                                                # set threshold to 14 for more sensitive search
       },
       -rc_name => '3GB',
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {
@@ -439,6 +442,7 @@ sub pipeline_analyses {
         %{ get_analysis_settings( 'Bio::EnsEMBL::Analysis::Hive::Config::GeneWiseStatic', 'targetted_genewise' ) },
       },
       -rc_name => '3GB',
+      -hive_capacity => $self->o('hc_normal'),
       -flow_into => {
         MEMLIMIT => ['targetted_genewise_gtag_6GB'],
       },
@@ -459,6 +463,7 @@ sub pipeline_analyses {
         %{ get_analysis_settings( 'Bio::EnsEMBL::Analysis::Hive::Config::GeneWiseStatic', 'targetted_genewise' ) },
       },
       -rc_name => '6GB',
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {
@@ -476,6 +481,7 @@ sub pipeline_analyses {
         %{ get_analysis_settings( 'Bio::EnsEMBL::Analysis::Hive::Config::GeneWiseStatic', 'targetted_exonerate' ) },
       },
       -rc_name => '3GB',
+      -hive_capacity => $self->o('hc_normal'),
       -flow_into => {
         MEMLIMIT => ['targetted_exo_6GB'],
       },
@@ -496,6 +502,7 @@ sub pipeline_analyses {
         %{ get_analysis_settings( 'Bio::EnsEMBL::Analysis::Hive::Config::GeneWiseStatic', 'targetted_exonerate' ) },
       },
       -rc_name => '6GB',
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {
@@ -568,6 +575,7 @@ sub pipeline_analyses {
         calculate_coverage_and_pid => 0,
       },
       -batch_size => 100,
+      -hive_capacity => $self->o('hc_normal'),
       -flow_into  => {
         -1 => ['exonerate_retry'],
       },
@@ -594,6 +602,7 @@ sub pipeline_analyses {
         calculate_coverage_and_pid => 0,
       },
       -batch_size           => 100,
+      -hive_capacity => $self->o('hc_normal'),
       -failed_job_tolerance => 100,
       -can_be_empty         => 1,
     },
@@ -713,6 +722,7 @@ sub pipeline_analyses {
         SOFT_MASKED_REPEATS        => '#wide_repeat_logic_names#',
       },
       -batch_size => 10,
+      -hive_capacity => $self->o('hc_normal'),
       -flow_into  => {
         '-1' => ['cdna2genome_himem'],
       },
@@ -737,6 +747,7 @@ sub pipeline_analyses {
         repeat_libraries           => '#wide_repeat_logic_names#',
       },
       -batch_size => 10,
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/FinaliseCoreDB.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/FinaliseCoreDB.pm
@@ -210,7 +210,7 @@ sub pipeline_analyses {
       },
       -rc_name => '4GB',
       -max_retry_count => 1,
-      -analysis_capacity => 400,
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/GenblastHomology.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/GenblastHomology.pm
@@ -318,7 +318,7 @@ sub pipeline_analyses {
         -2 => ['split_genblast_jobs'],
         -3 => ['split_genblast_jobs'],
       },
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {
@@ -364,7 +364,7 @@ sub pipeline_analyses {
         -2 => ['failed_genblast_proteins'],
         -3 => ['failed_genblast_proteins'],
       },
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {
@@ -449,6 +449,7 @@ sub pipeline_analyses {
         target_type => 'biotype_priority',
         layers      => get_analysis_settings( 'Bio::EnsEMBL::Analysis::Hive::Config::LayerAnnotationStatic', $self->o('uniprot_set'), undef, 'ARRAY' ),
       },
+      -hive_capacity => $self->o('hc_normal'),
       -rc_name => '5GB',
     },
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/HiveBaseConfig_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/HiveBaseConfig_conf.pm
@@ -122,6 +122,12 @@ sub default_options {
         linuxbrew_home_path => $ENV{LINUXBREW_HOME},
         binary_base => catdir($self->o('linuxbrew_home_path'), 'bin'),
 
+        hc_minimal => 20,
+        hc_low => 50,
+        hc_medium => 100,
+        hc_normal => 200,
+        hc_high => 1000,
+
         guihive_host => 'http://guihive.ebi.ac.uk',
         guihive_port => 8080,
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/HomologyRnaseq.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/HomologyRnaseq.pm
@@ -277,6 +277,7 @@ sub pipeline_analyses {
         target_type => 'biotype_priority',
         layers      => get_analysis_settings('Bio::EnsEMBL::Analysis::Hive::Config::LayerAnnotationStatic', $self->o('uniprot_set'), undef, 'ARRAY'),
       },
+      -hive_capacity => $self->o('hc_normal'),
       -rc_name    => '5GB',
     },
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/OtherFeatureDb.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/OtherFeatureDb.pm
@@ -299,7 +299,7 @@ sub pipeline_analyses {
       },
       -rc_name => 'default',
       -batch_size => 30,
-      -hive_capacity => 200,
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Projection_subpipeline_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Projection_subpipeline_conf.pm
@@ -270,7 +270,7 @@ sub pipeline_analyses {
       },
       -rc_name        => 'project_transcripts',
       -batch_size     => 100,
-      -hive_capacity  => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_low'),
     },
 
     {
@@ -304,7 +304,7 @@ sub pipeline_analyses {
       },
       -rc_name        => 'project_transcripts_himem',
       -batch_size     => 100,
-      -hive_capacity  => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_low'),
       -can_be_empty   => 1,
     },
 
@@ -352,7 +352,7 @@ sub pipeline_analyses {
         'stops2introns'         => 1,
       },
       -rc_name              => '3GB',
-      -analysis_capacity    => 50,
+      -hive_capacity => $self->o('hc_low'),
       -max_retry_count      => 1,
       -failed_job_tolerance => 5,
       -flow_into => {
@@ -379,7 +379,7 @@ sub pipeline_analyses {
         'stops2introns'         => 1,
       },
       -rc_name              => '15GB',
-      -analysis_capacity    => 50,
+      -hive_capacity => $self->o('hc_low'),
       -max_retry_count      => 1,
       -can_be_empty         => 1,
       -failed_job_tolerance => 5,
@@ -405,7 +405,7 @@ sub pipeline_analyses {
         'stops2introns'         => 1,
       },
       -rc_name              => '30GB',
-      -analysis_capacity    => 50,
+      -hive_capacity => $self->o('hc_low'),
       -max_retry_count      => 1,
       -can_be_empty         => 1,
       -failed_job_tolerance => 10,

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/RepeatMasking.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/RepeatMasking.pm
@@ -260,7 +260,7 @@ sub pipeline_analyses {
         '-1' => ['rebatch_repeatmasker'],
         '-2' => ['rebatch_repeatmasker'],
       },
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {
@@ -298,7 +298,7 @@ sub pipeline_analyses {
         -1 => ['failed_repeatmasker_batches'],
         -2 => ['failed_repeatmasker_batches'],
       },
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_normal'),
       -can_be_empty  => 1,
     },
 
@@ -340,7 +340,7 @@ sub pipeline_analyses {
         '-1' => ['rebatch_repeatmasker_repeatmodeler'],
         '-2' => ['rebatch_repeatmasker_repeatmodeler'],
       },
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {
@@ -377,7 +377,7 @@ sub pipeline_analyses {
         -1 => ['failed_repeatmasker_repeatmodeler_batches'],
         -2 => ['failed_repeatmasker_repeatmodeler_batches'],
       },
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_normal'),
       -can_be_empty  => 1,
     },
 
@@ -566,7 +566,7 @@ sub pipeline_analyses {
         -1 => ['run_trf'],
         -2 => ['run_trf'],
       },
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_normal'),
       -batch_size    => 20,
     },
 
@@ -586,7 +586,7 @@ sub pipeline_analyses {
 	  -1 => ['fan_post_repeat_analyses'],
 	  -2 => ['fan_post_repeat_analyses'],
       },
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_normal'),
       -batch_size    => 20,
     },
 
@@ -619,7 +619,7 @@ sub pipeline_analyses {
 	  -1 => ['run_cpg'],
 	  -2 => ['run_cpg'],
       },
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_normal'),
       -batch_size => 20,
     },
 
@@ -639,7 +639,7 @@ sub pipeline_analyses {
 	  -1 => ['run_trnascan'],
 	  -2 => ['run_trnascan'],
       },
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_normal'),
       -batch_size => 20,
     },
 
@@ -654,7 +654,7 @@ sub pipeline_analyses {
 	  trnascan_path => $self->o('trnascan_path'),
       },
       -rc_name    => 'simple_features',
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_normal'),
       -batch_size => 20,
     },
       

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/StarScallopRnaseq.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/StarScallopRnaseq.pm
@@ -806,6 +806,7 @@ sub pipeline_analyses {
         %{ get_analysis_settings( 'Bio::EnsEMBL::Analysis::Hive::Config::BlastStatic', 'BlastGenscanPep', { BLAST_PARAMS => { -type => $self->o('blast_type') } } ) },
         commandline_params => $self->o('blast_type') eq 'wu' ? '-cpus=' . $self->o('use_threads') . ' -hitdist=40' : '-num_threads ' . $self->o('use_threads') . ' -window_size 40',
       },
+      -hive_capacity => $self->o('hc_normal'),
       -flow_into => {
         '-1' => ['blast_scallop_longseq'],
         '2'  => ['blast_scallop_longseq'],
@@ -828,6 +829,7 @@ sub pipeline_analyses {
         %{ get_analysis_settings( 'Bio::EnsEMBL::Analysis::Hive::Config::BlastStatic', 'BlastGenscanPep', { BLAST_PARAMS => { -type => $self->o('blast_type') } } ) },
         commandline_params => $self->o('blast_type') eq 'wu' ? '-cpus=' . $self->o('use_threads') . ' -hitdist=40' : '-num_threads ' . $self->o('use_threads') . ' -window_size 40',
       },
+      -hive_capacity => $self->o('hc_normal'),
       -rc_name => '10GB_multithread',
     },
 
@@ -953,6 +955,7 @@ sub pipeline_analyses {
         target_db   => $self->o('rnaseq_for_layer_nr_db'),
         target_type => 'generic',
       },
+      -hive_capacity => $self->o('hc_normal'),
       -rc_name => '5GB',
     },
 
@@ -1140,6 +1143,7 @@ sub pipeline_analyses {
         target_db   => $self->o('pcp_nr_db'),
         target_type => 'generic',
       },
+      -hive_capacity => $self->o('hc_normal'),
       -rc_name => '5GB',
     },
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/TranscriptSelection.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/TranscriptSelection.pm
@@ -500,7 +500,7 @@ sub pipeline_analyses {
         iid_type       => 'slice',
       },
       -batch_size    => 100,
-      -hive_capacity => $self->hive_capacity_classes->{'hc_medium'},
+      -hive_capacity => $self->o('hc_medium'),
       -rc_name       => '5GB',
       -flow_into     => {
         '2' => ['layer_annotation'],
@@ -530,6 +530,7 @@ sub pipeline_analyses {
         LAYERS => get_analysis_settings( 'Bio::EnsEMBL::Analysis::Hive::Config::LayerAnnotationStatic', $self->o('uniprot_set'), undef, 'ARRAY' ),
       },
       -rc_name   => '4GB',
+      -hive_capacity => $self->o('hc_medium'),
       -flow_into => {
         '1->A' => ['run_utr_addition'],
         'A->1' => ['genebuilder'],
@@ -550,7 +551,7 @@ sub pipeline_analyses {
         iid_type               => 'slice',
       },
       -batch_size    => 20,
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_medium'),
       -rc_name       => '5GB',
       -flow_into     => {
         -1 => ['run_utr_addition_10GB'],
@@ -570,7 +571,7 @@ sub pipeline_analyses {
         iid_type               => 'slice',
       },
       -batch_size    => 20,
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_medium'),
       -rc_name       => '10GB',
       -flow_into     => {
         -1 => ['run_utr_addition_30GB'],
@@ -590,7 +591,7 @@ sub pipeline_analyses {
         iid_type               => 'slice',
       },
       -batch_size    => 20,
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_medium'),
       -rc_name       => '30GB',
       -flow_into     => {
         -1 => ['utr_memory_failover'],
@@ -611,7 +612,7 @@ sub pipeline_analyses {
         copy_only              => 1,
       },
       -batch_size    => 20,
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_medium'),
       -rc_name       => '10GB',
     },
 
@@ -651,7 +652,7 @@ sub pipeline_analyses {
         CODING_ONLY => 1,
       },
       -rc_name       => '4GB',
-      -hive_capacity => $self->hive_capacity_classes->{'hc_high'},
+      -hive_capacity => $self->o('hc_medium'),
     },
 
     {
@@ -767,6 +768,7 @@ sub pipeline_analyses {
         module            => 'HivePseudogenes',
         %{ get_analysis_settings( 'Bio::EnsEMBL::Analysis::Hive::Config::PseudoGeneStatic', 'pseudogenes' ) },
       },
+      -hive_capacity => $self->o('hc_normal'),
       -rc_name   => '3GB',
     },
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/long_read.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/long_read.pm
@@ -320,7 +320,7 @@ sub pipeline_analyses {
         module                       => 'Minimap2',
       },
       -rc_name   => '15GB',
-      -analysis_capacity => 200,
+      -hive_capacity => $self->o('hc_normal'),
       -flow_into => {
         -1 => { 'minimap2_himem' => { 'input_file' => '#input_file#', 'iid' => '#iid#' } },
       },
@@ -340,7 +340,7 @@ sub pipeline_analyses {
         logic_name                   => 'minimap2',
         module                       => 'Minimap2',
       },
-      -analysis_capacity => 200,
+      -hive_capacity => $self->o('hc_normal'),
       -rc_name => '25GB',
     },
 
@@ -403,7 +403,7 @@ sub pipeline_analyses {
         use_strand     => 1,
       },
       -batch_size => 100,
-      -analysis_capacity => 200,
+      -hive_capacity => $self->o('hc_normal'),
       -rc_name    => '5GB',
       -flow_into  => {
         2 => { 'collapse_transcripts' => { 'slice_strand' => '#slice_strand#', 'iid' => '#iid#' } },
@@ -426,7 +426,7 @@ sub pipeline_analyses {
         -1 => { 'collapse_transcripts_20GB' => { 'slice_strand' => '#slice_strand#', 'iid' => '#iid#' } },
       },
       -batch_size        => 100,
-      -analysis_capacity => 200,
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {
@@ -445,7 +445,7 @@ sub pipeline_analyses {
         commandline_params => $self->o('blast_type') eq 'wu' ? '-cpus=' . $self->o('use_threads') . ' -hitdist=40' : '-num_threads ' . $self->o('use_threads') . ' -window_size 40 -seg no',
       },
       -rc_name   => 'blast',
-      -analysis_capacity => 200,
+      -hive_capacity => $self->o('hc_normal'),
       -flow_into => {
         -1 => ['blast_10G'],
       },
@@ -466,7 +466,7 @@ sub pipeline_analyses {
         %{ get_analysis_settings( 'Bio::EnsEMBL::Analysis::Hive::Config::BlastStatic', 'BlastGenscanPep', { BLAST_PARAMS => { -type => $self->o('blast_type') } } ) },
         commandline_params => $self->o('blast_type') eq 'wu' ? '-cpus=' . $self->o('use_threads') . ' -hitdist=40' : '-num_threads ' . $self->o('use_threads') . ' -window_size 40 -seg no',
       },
-      -analysis_capacity => 200,
+      -hive_capacity => $self->o('hc_normal'),
       -rc_name => 'blast10GB',
     },
 
@@ -486,7 +486,7 @@ sub pipeline_analyses {
         -1 => { 'failed_collapse' => { 'slice_strand' => '#slice_strand#', 'iid' => '#iid#' } },
       },
       -batch_size        => 10,
-      -analysis_capacity => 200,
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {
@@ -499,7 +499,7 @@ sub pipeline_analyses {
         biotypes   => [ "isoseq", "cdna" ],
         copy_only  => 1,
       },
-      -analysis_capacity => 200,
+      -hive_capacity => $self->o('hc_normal'),
       -rc_name   => '10GB',
       -flow_into => {
         1 => { 'blast' => { 'slice_strand' => '#slice_strand#', 'iid' => '#iid#' } },

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/production_rnaseq_db.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/production_rnaseq_db.pm
@@ -263,7 +263,7 @@ sub pipeline_analyses {
           ' -idfile #id_file#'
       },
       -rc_name => 'default',
-      -hive_capacity => 200,
+      -hive_capacity => $self->o('hc_normal'),
     },
 
     {

--- a/scripts/genebuild/create_annotation_configs.pl
+++ b/scripts/genebuild/create_annotation_configs.pl
@@ -37,7 +37,7 @@ my $config_only = 0;
 my $custom_load = 0;
 my $early_load = 0;
 
-my $total_running_workers_max = 200;
+my $total_running_workers_max = 2000;
 my $base_guihive = 'http://guihive.ebi.ac.uk:8080';
 my $ftphost = "ftp.ncbi.nlm.nih.gov";
 my $ftpuser = "anonymous";


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
Feature
_Include a short description_
Remove the limit we set to hive of 200 workers max. We set the limit using `-hive_capacity` for the analyses which needs to be controlled for their MySQL servers access
_Include links to JIRA tickets_
NA
# Testing
_Have you tested it?_
Yes
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
