### PR TITLE
set retry as zero in get_read_length

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/StarScallopRnaseq.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/StarScallopRnaseq.pm
@@ -442,6 +442,7 @@ sub pipeline_analyses {
         read_length_table => $self->o('read_length_table'),
         _input_id_name => 'filename',
       },
+      -max_retry_count => 0,
     },
 
     {


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
fix
_Include a short description_
The default retry in get_reads_length causes a failure for duplicated key in the read_length table. The job should be run without retrying
_Include links to JIRA tickets_

# Testing
_Have you tested it?_
yes
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
@ndliberial @ens-carlos 