### PR TITLE
Added species_id parameter

### DIFF
--- a/scripts/assembly_loading/load_seq_region.pl
+++ b/scripts/assembly_loading/load_seq_region.pl
@@ -104,6 +104,7 @@ my $sequence_level = 0;
 my $agp;
 my $fasta;
 my $rank;
+my $species_id;
 my $verbose = 0;
 my $regex;
 my $name_file;
@@ -119,6 +120,7 @@ GetOptions(
             'coord_system_name|cs_name:s' => \$cs_name,
             'coord_system_version:s' => \$cs_version,
             'rank:i' => \$rank,
+	    'species_id:i' => \$species_id,
             'sequence_level!' => \$sequence_level,
             'default_version!' => \$default,
             'agp_file:s' => \$agp,
@@ -153,6 +155,8 @@ if(!$rank) {
     $help = 1;
 }
 
+$species_id ||= 1; #default to species id 1 if not defined
+
 if ($help) {
     exec('perldoc', $0);
 }
@@ -164,7 +168,8 @@ my $db = Bio::EnsEMBL::DBSQL::DBAdaptor->new(
     -host   => $host,
     -user   => $dbuser,
     -port   => $port,
-    -pass   => $dbpass
+    -pass   => $dbpass,
+    -species_id => $species_id,
 );
 
 
@@ -256,8 +261,8 @@ sub parse_fasta{
     print( "Loading ".$name."\n" ) if($verbose) ;
     if( $name !~ /^\w+\.\d/ || length($name)>40 )
     {
-        warning( "Name ".$name." does not look like a valid accession - are you sure ".
-            "this is what you want?" )
+	    #    warning( "Name ".$name." does not look like a valid accession - are you sure ".
+	    #"this is what you want?" )
     }
 
     my $slice = &make_slice($name, 1, $seq->length, $seq->length, 1, $cs);

--- a/scripts/assembly_loading/load_seq_region.pl
+++ b/scripts/assembly_loading/load_seq_region.pl
@@ -261,8 +261,8 @@ sub parse_fasta{
     print( "Loading ".$name."\n" ) if($verbose) ;
     if( $name !~ /^\w+\.\d/ || length($name)>40 )
     {
-	    #    warning( "Name ".$name." does not look like a valid accession - are you sure ".
-	    #"this is what you want?" )
+	  warning( "Name ".$name." does not look like a valid accession - are you sure ".
+	    "this is what you want?" )
     }
 
     my $slice = &make_slice($name, 1, $seq->length, $seq->length, 1, $cs);


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_

This is an update.

_Include a short description_

The default behaviour for most data loading activities is to have a species ID of 1. However, for microbial collection databases, we need species IDs that are not one. By adding the species_id as a parameter when creating the DB Adaptor, it can link the coord systems to species that have a different id.

_Include links to JIRA tickets_

# Testing
_Have you tested it?_
Yes. I have tested it with a species ID and also without (when it should default to 1)

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
