### PR TITLE
Add pre_cleanup to CleanUTR

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/CleanUTRs.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/CleanUTRs.pm
@@ -141,4 +141,19 @@ sub write_output {
   }
 }
 
+
+sub pre_cleanup {
+  my ($self) = @_;
+
+  if ($self->param_is_defined('target_db')) {
+    my $db = $self->get_database_by_name('target_db');
+    my $slice = $db->get_SliceAdaptor->fetch_by_name($self->input_id);
+    my $gene_adaptor = $db->get_GeneAdaptor;
+    foreach my $gene (@{$slice->fetch_all_Genes}) {
+      $self->warning('Deleting gene '.$gene->dbID);
+      $gene_adaptor->remove($gene);
+    }
+  }
+}
+
 1;


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
New feature

_Include a short description_
To avoid duplicated genes when the CleanUTR analysis copy the genes I have added a pre_cleanup method which will delete all genes in the target database which are the input_id region

_Include links to JIRA tickets_
NA
# Testing
_Have you tested it?_
Yes
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
