### PR TITLE
Skip transcript checks for the sanity checks

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveAnalysisSanityCheck.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveAnalysisSanityCheck.pm
@@ -147,15 +147,13 @@ sub gene_db_checks {
     my $observed_logic_name_counts = {};
     foreach my $slice (@$slices) {
       foreach my $gene (@{$slice->get_all_Genes}) {
-        foreach my $transcript (@{$gene->get_all_Transcripts}) {
-          my $biotype = $transcript->biotype;
+          my $biotype = $gene->biotype;
           if (exists $observed_biotype_counts->{$biotype}) {
             $observed_biotype_counts->{$biotype}++;
           }
           else {
             $observed_biotype_counts->{$biotype} = 1;
           }
-        }
         my $logic_name = $gene->analysis->logic_name;
         if (exists $observed_logic_name_counts->{$logic_name}) {
           $observed_logic_name_counts->{$logic_name}++;
@@ -186,7 +184,7 @@ sub gene_db_checks {
 
     }
 
-    # Count the transcripts per biotype
+    # Count the gene per biotype
     # Not particularly happy with this, I think it is good to have a way to specify generic parts of a biotype, but it comes at the
     # expense of having to pattern match, which is dangerous
     $self->say_with_header("Checking biotypes:");


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
Fix
_Include a short description_
Genebuild sanity checks are failing because the gene biotype is updated but the transcript biotype still not (it is update during core finalisation) so the script can find the correct count of transcript per biotype. The code has been updated to check the count of gene per biotype
_Include links to JIRA tickets_

# Testing
_Have you tested it?_
yes 
# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
@leannehaggerty @williamstark01 