### PR TITLE
https -> http to fix file fetch

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/LoadAssembly.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/LoadAssembly.pm
@@ -129,7 +129,7 @@ sub default_options {
 ########################################################
 # URLs for retrieving the INSDC contigs and RefSeq files
 ########################################################
-    ncbi_base_ftp           => 'https://ftp.ncbi.nlm.nih.gov/genomes/all',
+    ncbi_base_ftp           => 'http://ftp.ncbi.nlm.nih.gov/genomes/all',
     insdc_base_ftp          => $self->o('ncbi_base_ftp').'/#expr(substr(#assembly_accession#, 0, 3))expr#/#expr(substr(#assembly_accession#, 4, 3))expr#/#expr(substr(#assembly_accession#, 7, 3))expr#/#expr(substr(#assembly_accession#, 10, 3))expr#/#assembly_accession#_#assembly_name#',
     assembly_ftp_path       => $self->o('insdc_base_ftp'),
 


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
Download from genebank was failing using File::Fetch because the FTP base path was using http vs. https
https://www.ebi.ac.uk/panda/jira/browse/ENSGENEBUI-1176

# Testing
Yes in this pipeline (not that assembly loading is currently still failing due to a problem with the assebly report itself, but the downloads have all worked fine)
mysql://ensadmin:xxxxx@mysql-ens-genebuild-prod-4:4530/leanne_gca002880755v3_load_assembly_pipe_107

# Assign to the weekly GitHub reviewer
