### PR TITLE
Fix fish sanity checks for gbuild and final

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
@@ -546,7 +546,8 @@ sub _master_config {
         'logic_names' => {
           'ensembl'             => 19000,
         }, # logic_names
-	'biotypes' =>    {
+	    'biotypes' =>    {
+		'rnaseq_tissue_'      => 10000,
         }, # biotypes
       }, # genebuilder
       'ncrna' => {
@@ -567,8 +568,8 @@ sub _master_config {
           'ncrna'               => 500,
         }, # logic_names
         'biotypes' =>    {
-          'protein_coding'      => 19000,
-          'lncRNA'              => 5,
+          'rnaseq_tissue_'      => 10000,
+          'lncRNA'              => 2000,
           'miRNA'               => 30,
           'misc_RNA'            => 5,
           'rRNA'                => 50,


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
Fix - stop saniity checks constantly failing at final

removed protein-coding from list of biotypes for final db (not present for transcripts at this point)
added rnaseq_tissue to list of biotypes for gbuild and final (for fish we are reliant on rnaseq - no projection)
increased lncRNA count for final (there should be a high number given rnaseq data and newer lncRNA code)

# Testing
yes

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
