### PR TITLE
url_base correction for download

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/Refseq_import_subpipeline.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/Refseq_import_subpipeline.pm
@@ -113,7 +113,7 @@ sub default_options {
     ########################################################
     # URLs for retrieving the INSDC contigs and RefSeq files
     ########################################################
-    'ncbi_base_ftp' => 'https://ftp.ncbi.nlm.nih.gov/genomes/all',
+    'ncbi_base_ftp' => 'http://ftp.ncbi.nlm.nih.gov/genomes/all',
     'refseq_base_ftp'        => $self->o('ncbi_base_ftp') . '/#expr(substr(#assembly_refseq_accession#, 0, 3))expr#/#expr(substr(#assembly_refseq_accession#, 4, 3))expr#/#expr(substr(#assembly_refseq_accession#, 7, 3))expr#/#expr(substr(#assembly_refseq_accession#, 10, 3))expr#/#assembly_refseq_accession#_#assembly_name#',
     'refseq_import_ftp_path' => $self->o('refseq_base_ftp') . '/#assembly_refseq_accession#_#assembly_name#_genomic.gff.gz',
     'refseq_report_ftp_path' => $self->o('refseq_base_ftp') . '/#assembly_refseq_accession#_#assembly_name#_assembly_report.txt',


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
Fix.

There was a change from web to adapt urls security that causes the script to fail in retrieving the ftp data for refseq annotation. this changes back to a working state

[ENSGENEBUI-1471](https://www.ebi.ac.uk/panda/jira/browse/ENSGENEBUI-1471)

# Testing
yes -> http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-genebuild-prod-7&port=4533&dbname=jose_gca002263795v3_refseq_import_pipe_109&passwd=xxxxx

# Assign to the weekly GitHub reviewer
@leannehaggerty @ens-ftricomi 
