### PR TITLE
Updated query to match only genebuild in progress

### DIFF
--- a/scripts/update_assembly_registry.pl
+++ b/scripts/update_assembly_registry.pl
@@ -65,19 +65,21 @@ my $registry_dba = new Bio::EnsEMBL::Analysis::Hive::DBSQL::AssemblyRegistryAdap
   -driver  => $driver,);
 
 my $registry_assembly_id = $registry_dba->fetch_assembly_id_by_gca($assembly_accession);
-my $sth = $registry_dba->dbc->prepare("UPDATE genebuild_status set progress_status =? where assembly_id=? and is_current=?");
+my $sth = $registry_dba->dbc->prepare("UPDATE genebuild_status set progress_status =? where assembly_id=? and is_current=? and annotation_status = ?");
 $sth->bind_param(1,'completed');
 $sth->bind_param(2,$registry_assembly_id);
 $sth->bind_param(3,1);
+$sth->bind_param(4,'pending');
 if ($sth->execute){
 }
 else{
  $self->throw("Could not update genebuild status with annotation progress");
 }
-$sth = $registry_dba->dbc->prepare("UPDATE genebuild_status set date_completed =? where assembly_id=? and is_current=?");
+$sth = $registry_dba->dbc->prepare("UPDATE genebuild_status set date_completed =? where assembly_id=? and is_current=? and annotation_status = ?");
 $sth->bind_param(1,$date);
 $sth->bind_param(2,$registry_assembly_id);
 $sth->bind_param(3,1);
+$sth->bind_param(4,'pending');
 if ($sth->execute){
 }   
 else{


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
A fix

_Include a short description_
With multiple annotations in the genebuild status table at any point in time, it is best that the update query is limited to the genebuild status entry for the assembly whose annotation status is "pending".
_Include links to JIRA tickets_

# Testing
Yes

# Assign to the weekly GitHub reviewer
@ndliberial 
