### PR TITLE
Catch different spellings of the Genbank database name in the Dbxref …

### DIFF
--- a/scripts/refseq/parse_ncbi_gff3.pl
+++ b/scripts/refseq/parse_ncbi_gff3.pl
@@ -771,7 +771,7 @@ sub add_xrefs {
     }
     $object->add_DBEntry($xrefs_hash->{$xref});
     if ($object->can('display_xref')) {
-      if ($xrefs_hash->{$xref}->dbname eq 'Genbank') {
+      if ($xrefs_hash->{$xref}->dbname eq 'Genbank' or $xrefs_hash->{$xref}->dbname eq 'GenBank') {
         $object->display_xref($xrefs_hash->{$xref});
       }
       elsif ($object->isa('Bio::EnsEMBL::Gene') and $xrefs_hash->{$xref}->dbname eq 'EntrezGene') {


### PR DESCRIPTION
…attribute values of the RefSeq annotation files

# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
Update

_Include a short description_
In the newest RefSeq annotation gff3 files (*-RS_2023_06), the Dbxref database name for 'Genbank' has been updated to 'GenBank'. The current import script will miss the new spelling, so the RefSeq transcripts will not have a Genbank display xref (eg. NM_001099460.3). As a consequence of this, the Xref pipeline will create far fewer RefSeq xrefs in the core database, since it requires that the 'refseq_import' annotation in the otherfeatures database have Genbank-like display xrefs.

_Include links to JIRA tickets_

# Testing
_Have you tested it?_
Yes, I tested it in the human and mouse release 111 databases.

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
Jose