### PR TITLE
Use anno implementation of red

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ We recommend that you clone all the repositories into one directory
 | ensembl-datacheck | default | https://github.com/Ensembl/ensembl-datacheck.git |
 | ensembl-metadata | default | https://github.com/Ensembl/ensembl-metadata.git |
 | ensembl-io | default | https://github.com/Ensembl/ensembl-io.git |
+| ensembl-variation | default | https://github.com/Ensembl/ensembl-variation.git |
 
 For each of these repository, you will need to install their dependencies using the cpanfile provided in their Git repositories
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/RepeatMasking.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/RepeatMasking.pm
@@ -662,37 +662,11 @@ sub pipeline_analyses {
 # Run Red (REpeat Detector)
     {
       -logic_name => 'repeatdetector',
-      -module     => 'Repeatmask_Red',
-      -language   => 'python3',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
       -parameters => {
-        logic_name     => $self->o('red_logic_name'),
-        red_path       => $self->o('red_path'),
-        genome_file    => $self->o('faidx_genome_file'),
-        target_db_url  => $self->o('hive_driver').'://'.$self->o('user').':'.$self->o('password').'@'.$self->o('dna_db_host').':'.$self->o('dna_db_port').'/'.$self->o('dna_db_name'),
-        msk            => $self->o('red_msk'),
-        rpt            => $self->o('red_rpt'),
-        red_meta_key   => $self->o('replace_repbase_with_red_to_mask'),
+	  cmd => 'python ' . catfile( $self->o('enscode_root_dir'), 'ensembl-anno', 'ensembl_anno.py' ) .' --genome_file '. $self->o('faidx_genome_file') .' --db_details '. $self->o('dna_db_name').','.$self->o('dna_db_host').','.$self->o('dna_db_port').','.$self->o('user').','.$self->o('password')  .' --output_dir '. $self->o('output_path') .' --num_threads 20 --run_masking --load_to_ensembl_db',
       },
-      -rc_name   => '15GB',
-      -flow_into => {
-        -1  => ['repeatdetector_50GB'],
-      },
-    },
-
-    {
-      -logic_name => 'repeatdetector_50GB',
-      -module     => 'Repeatmask_Red',
-      -language   => 'python3',
-      -parameters => {
-        logic_name     => $self->o('red_logic_name'),
-        red_path       => $self->o('red_path'),
-        genome_file    => $self->o('faidx_genome_file'),
-        target_db_url  => $self->o('hive_driver').'://'.$self->o('user').':'.$self->o('password').'@'.$self->o('dna_db_host').':'.$self->o('dna_db_port').'/'.$self->o('dna_db_name'),
-        msk            => $self->o('red_msk'),
-        rpt            => $self->o('red_rpt'),
-        red_meta_key   => $self->o('replace_repbase_with_red_to_mask'),
-      },
-      -rc_name => '50GB',
+      -rc_name   => '50GB',
     },
   ];
 }


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
Replacing the red python module with a call to ensembl-anno (-run_masking)
Included --load_to_ensembl_db so red repeats will be written to core db

NOTE: the ensembl-variation repo is required in ENSCODE (seems to be missing in new env), otherwise the write to core db will fail silently (we need to think about some error catching)

# Testing
Yes mysql://ensadmin:xxxxx@mysql-ens-genebuild-prod-4:4530/leanne_gca022416725v1_repeat_masking_pipe_109

# Assign to the weekly GitHub reviewer

