### PR TITLE
modifies module HiveCreateStarJobs.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveCreateStarJobs.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveCreateStarJobs.pm
@@ -113,7 +113,7 @@ sub batch_samples {
     my $sample = $samples_hash->{$sample_id};
     my $file_name = ${$sample->{'files'}}[0];
     my $file_path = catfile($fastq_dir,$file_name);
-    my $file_size = `stat -c %s $file_path`;
+    my $file_size = `stat -L -c %s $file_path`;
     chomp($file_size);
 
     unless($file_name =~ /\.gz$/) {


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
This is a fix.

When working with symlinks to fastq, the module reads the size of the symlinks files, not the referenced originals, and creates only one (1) star job as the real size is not being considered... This in turn slows down the pipeline, avoids parallelization, and incurrs in great time lost when this single star job fails and need to be restarted...

No Jira tickets created...

# Testing
I have tested with: http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-genebuild-prod-7&port=4533&dbname=jose_gca017957985v1_rnaseq_pipe_109&passwd=xxxxx (originally 1 star job, now 84)

# Assign to the weekly GitHub reviewer
Assigned @ens-ftricomi as reviewer per weekly dutty, and @swatiebi to comply with the two reviewers rule
