### PR TITLE
Remove out-of-date mammal genblast sanity checks

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
@@ -148,9 +148,7 @@ sub _master_config {
         }, # logic_names
         'biotypes' =>    {
           'human_pe12_'         => 20000,
-          'aves_pe12_'          => 15000,
-          'mammals_pe12_'       => 100000,
-          'reptiles_pe12_'      => 1000,
+          'mouse_pe12_'         => 20000,
         }, # biotypes
       }, # genblast
       'projection_coding' => {
@@ -177,7 +175,6 @@ sub _master_config {
         }, # logic_names
         'biotypes' =>    {
           'human_pe12_'          => 0,#not sure what value to set
-          'mammals_pe12_'        => 12000,
           'rnaseq_tissue_'       => 149000,
         }, # biotypes
       }, # layer


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
ganblast sanity checks fail because the mammals pe12 biotype is no longer present from the Uniprot download

# Testing
yes

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
