### PR TITLE
removed protein coding biotype from birs, primates and mammals final db

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
@@ -207,7 +207,6 @@ sub _master_config {
         'biotypes' =>    {
           'IG_'                  => 0,
           'TR_'                  => 0,
-          'protein_coding'      => 15000,
           'miRNA'               => 100,
           'misc_RNA'            => 3,
           'ribozyme'            => 0,
@@ -329,7 +328,6 @@ sub _master_config {
         'biotypes' =>    {
           'IG_'                  => 20,
           'TR_'                  => 20,
-          'protein_coding'      => 19000,
           'miRNA'               => 500,
           'misc_RNA'            => 1000,
           'ribozyme'            => 0,
@@ -428,7 +426,7 @@ sub _master_config {
           'ensembl'             => 19000,
         }, # logic_names
 	 'biotypes' =>    {
-        }, # biotypes  
+        }, # biotypes
       }, # genebuilder
       'ncrna' => {
         'logic_names' => {
@@ -452,7 +450,6 @@ sub _master_config {
         'biotypes' =>    {
           'IG_'                  => 20,
           'TR_'                  => 20,
-          'protein_coding'      => 19000,
           'miRNA'               => 500,
           'misc_RNA'            => 1000,
           'ribozyme'            => 0,


### PR DESCRIPTION
sanity checks

# Requirements
When creating your Pull request, please fill out the template below:

# PR details
Fix

_Include a short description_
The final db sanity checks for mammals, birds and primates look for the biotype protein coding which is now cleaned up.
_Include links to JIRA tickets_

# Testing
Yes

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
