### PR TITLE
Update SanityChecksStatic.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/SanityChecksStatic.pm
@@ -288,7 +288,6 @@ sub _master_config {
         'logic_names' =>    {
           'genblast'                => 100,
           'best_targetted'          => 100,
-          'genblast_rnaseq_support' => 1000,
           'project_transcripts' => 10000,
         }, # logic_names
         'biotypes' =>    {


### PR DESCRIPTION
the logic name 'genblast_rnaseq_support' is not present in the transcript table for layerDB so better to remove it.

# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
fix
_Include a short description_
the logic name 'genblast_rnaseq_support' is not present in the transcript table for layerDB so better to remove it.

_Include links to JIRA tickets_
https://www.ebi.ac.uk/panda/jira/browse/ENSGENEBUI-1679

# Testing
_Have you tested it?_
yes

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
