### PR TITLE
Update HiveCesar_conf.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/HiveCesar_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/HiveCesar_conf.pm
@@ -192,7 +192,7 @@ sub pipeline_analyses {
                          'compara_db' => $self->o('compara_db'),
                          'method_link_type' => $self->o('method_link_type'),
                          'cesar_path' => $self->o('cesar_path'),
-                         'cesar_mem' => '3', # mem in GB to be used by cesar (parameter --max-memory)
+                         'cesar_mem' => '10', # mem in GB to be used by cesar (parameter --max-memory)
                          #TRANSCRIPT_FILTER => {
                          #  OBJECT     => 'Bio::EnsEMBL::Analysis::Tools::ExonerateTranscriptFilter',
                          #  PARAMETERS => {


### PR DESCRIPTION
Increased the resource class for Cesar from 3 to 10GBs, I have noticed that the default cesar usually fails and the reason is usually less memory.

# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
fix

_Include a short description_
Cesar jobs fail because of memory issues. I think it is worth to increase the resource class to 10GB.

_Include links to JIRA tickets_

# Testing
_Have you tested it?_
Yes

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
