### PR TITLE
Added skip_analysis option to mergeBam

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveMergeBamFiles.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveMergeBamFiles.pm
@@ -113,6 +113,7 @@ sub param_defaults {
     _file_type => 'BAMCOV',
     _logic_name_ext => 'bam',
     samtools => 'samtools',
+	skip_analysis => 0,
   }
 }
 
@@ -138,6 +139,10 @@ sub param_defaults {
 
 sub fetch_input {
     my ($self) = @_;
+
+	if ($self->param('skip_analysis')) {
+    	$self->complete_early('I was asked to skip this analysis');
+  	}
 
     my $input_files = $self->param('filename');
     if (@$input_files) {
@@ -188,10 +193,10 @@ sub fetch_input {
 
           $samtools->index($alignment_bam_file);
         }
-        # save file to datafile table. 
+        # save file to datafile table.
         if ($self->param('store_datafile')) {
           $self->store_filename_into_datafile;
-        }        
+        }
         # Finally tell Hive that we've finished processing
         $self->dataflow_output_id({filename => $alignment_bam_file}, $self->param('_branch_to_flow_to'));
         $self->complete_early('There is only one file to process');
@@ -266,7 +271,7 @@ sub write_output {
     if ($self->param('store_datafile')) {
       $self->store_filename_into_datafile;
     }
-    $self->dataflow_output_id({filename => $self->output->[0]}, $self->param('_branch_to_flow_to')); 
+    $self->dataflow_output_id({filename => $self->output->[0]}, $self->param('_branch_to_flow_to'));
 }
 
 

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveStar.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveStar.pm
@@ -73,7 +73,6 @@ sub param_defaults {
     threads => 1,
     samtools => 'samtools',
     samtools_use_threading => 1,
-	skip_analysis => 0,
   }
 }
 
@@ -91,10 +90,6 @@ sub param_defaults {
 
 sub fetch_input {
   my ($self) = @_;
-
-  if ($self->param('skip_analysis')) {
-	$self->complete_early('I was asked to skip this analysis');
-  }
 
   my $input_ids = $self->param('SM');
   $self->say_with_header('Found '.scalar(@$input_ids).' input ids');
@@ -131,7 +126,6 @@ sub fetch_input {
      -fastq          => $filepath1,
      -fastqpair      => $filepath2,
      -threads        => $self->param('num_threads'),
-	 #-mem_request	 => $self->param('limitBAM'),
     );
     if ($self->param_is_defined('rg_lines')) {
       $runnable->rg_lines($self->param('rg_lines'));

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveStar.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveStar.pm
@@ -73,6 +73,7 @@ sub param_defaults {
     threads => 1,
     samtools => 'samtools',
     samtools_use_threading => 1,
+	skip_analysis => 0,
   }
 }
 
@@ -90,6 +91,10 @@ sub param_defaults {
 
 sub fetch_input {
   my ($self) = @_;
+
+  if ($self->param('skip_analysis')) {
+	$self->complete_early('I was asked to skip this analysis');
+  }
 
   my $input_ids = $self->param('SM');
   $self->say_with_header('Found '.scalar(@$input_ids).' input ids');
@@ -126,6 +131,7 @@ sub fetch_input {
      -fastq          => $filepath1,
      -fastqpair      => $filepath2,
      -threads        => $self->param('num_threads'),
+	 #-mem_request	 => $self->param('limitBAM'),
     );
     if ($self->param_is_defined('rg_lines')) {
       $runnable->rg_lines($self->param('rg_lines'));

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveStar.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveStar.pm
@@ -93,7 +93,7 @@ sub fetch_input {
   my ($self) = @_;
 
   if ($self->param('skip_analysis')) {
-	$self->complete_early('I was asked to skip this analysis');
+	$self->complete_early('I was asked to skip this analysis',2);
   }
 
   my $input_ids = $self->param('SM');

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/Scallop.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/Scallop.pm
@@ -64,7 +64,6 @@ sub param_defaults {
     input_file_extensions => ['_Aligned.sortedByCoord.out.bam','.mb.sorted.bam','.bam'],
     num_threads => 1,
     delete_input_file => 0,
-	skip_analysis => 0,
   }
 }
 
@@ -81,10 +80,6 @@ sub param_defaults {
 
 sub fetch_input {
   my ($self) = @_;
-
-  if ($self->param('skip_analysis')) {
-    $self->complete_early('I was asked to skip this analysis');
-  }
 
   my $input_ids = [$self->param('iid')];
   unless(scalar(@$input_ids)) {

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/Scallop.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/Scallop.pm
@@ -64,6 +64,7 @@ sub param_defaults {
     input_file_extensions => ['_Aligned.sortedByCoord.out.bam','.mb.sorted.bam','.bam'],
     num_threads => 1,
     delete_input_file => 0,
+	skip_analysis => 0,
   }
 }
 
@@ -80,6 +81,10 @@ sub param_defaults {
 
 sub fetch_input {
   my ($self) = @_;
+
+  if ($self->param('skip_analysis')) {
+    $self->complete_early('I was asked to skip this analysis');
+  }
 
   my $input_ids = [$self->param('iid')];
   unless(scalar(@$input_ids)) {


### PR DESCRIPTION
Allows for skipping analysis if merging has happened but pipeline needs to re-run for any reason.

# Requirements
None

# PR details
Sort of fix for weird unfrequent scenarios

_Include a short description_

allows to skip analysis MergeBams from rnaseq pipeline, which could be needed if you have already merged said bams and need to, for some reason, re-run the pipeline without wasting the time and resources in repeating. add skip_analysis = 1 in the arameters of the analysis and go.

_Include links to JIRA tickets_

# Testing
_Have you tested it?_

yes

# Assign to the weekly GitHub reviewer

@AnnaLazarEBI @leannehaggerty (adding anna because of rota, and leanne for support, message me for more info or help if needed)
