### PR TITLE
update long_read_columns to include additional metadata fields

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/long_read.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/long_read.pm
@@ -132,7 +132,7 @@ sub default_options {
     # This is just an example based on the file snippet shown below.  It
     # will vary depending on how your data looks.
     ####################################################################
-    long_read_columns => [ 'sample', 'filename', 'description', 'fastq_file', 'fastq_md5' ],
+    long_read_columns => ['sample','run_accession','is_paired','filename','is_mate_1','read_length','is_plus_13','centre','instrument_platform','description','fastq_file','fastq_md5'],
     download_method => 'ftp',
     databases_to_delete => ['long_read_initial_db', 'long_read_collapse_db', 'long_read_final_db'],
 


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
Fix.

The python script that creates the csv with the long read information retrieves more metadata than previous versions of the code. The config module is expecting only 5 columns, and it fails in retrieving the url.
By changing the column names expected, the module behaves as expected and the jobs are created normally.

No Jira Tickets.

# Testing
I have tested the download analysis. I'll make this PR a draft to see if any down-the-line analyses are affected, but so far it looks like they aren't. When the whole subpipeline finishes, I'll publish the PR.

# Assign to the weekly GitHub reviewer
@vianeyBE  (I'm in the rotas this week)
