### PR TITLE
Add pepstats to pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/FinaliseCoreDB.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/FinaliseCoreDB.pm
@@ -655,9 +655,24 @@ sub pipeline_analyses {
           ' -registry_port ' . $self->o('registry_port') .
           ' -registry_db ' . $self->o('registry_db'),
       },
-      -rc_name => 'default',
+	  -rc_name => 'default',
+	  -flow_into       => {
+             1 => ['pepstats'], },
     },
-
+ 
+      {
+	  -logic_name => 'pepstats',
+	  -module     => 'Bio::EnsEMBL::Production::Pipeline::Production::PepStatsBatch',
+	  -parameters => {
+	      dbtype => 'core',
+	      pepstats_binary => 'pepstats',
+	      tmpdir => $self->o('output_path'),
+	  },
+	  -max_retry_count => 1,
+	  -hive_capacity   => 50,
+	  -rc_name => '50GB',
+      },
+ 
   ];
 }
 


### PR DESCRIPTION
# PR details
This module used to be run as part of the Automation CoreStats pipeline - it add transcript attributes that are required for the release. 
To reduce redundancy, this is being moved to our pipelines so that the attributes will be added on our dbs before handover. 

# Testing
I need this to be merged and tested the next time the pipeline is run

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
