### PR TITLE
Added the parameter species and reg_conf

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/FinaliseCoreDB.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/FinaliseCoreDB.pm
@@ -665,7 +665,9 @@ sub pipeline_analyses {
 	  -module     => 'Bio::EnsEMBL::Production::Pipeline::Production::PepStatsBatch',
 	  -parameters => {
 	      dbtype => 'core',
+	      species => $self->o('production_name'),
 	      pepstats_binary => 'pepstats',
+	      reg_conf => $self->o('registry_file'),
 	      tmpdir => $self->o('output_path'),
 	  },
 	  -max_retry_count => 1,


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
fix
_Include a short description_
I have added couple of parameters to the PepstatsBatch module in FinaliseCoreDB module config. These are species and reg_conf, the reg_conf is required by the production code `modules/Bio/EnsEMBL/Production/Pipeline/Production/PepStatsBatch.pm` where I have added an if condition to read the registry file from the current annotation.
This PR will only work if the changes in `modules/Bio/EnsEMBL/Production/Pipeline/Production/PepStatsBatch.pm` are made which are as under:
```
 my $reg_conf = $self->param('reg_conf');  # Get the reg_conf parameter
  # Load registry if reg_conf is provided
  if ($reg_conf) {
   Bio::EnsEMBL::Registry->load_all($reg_conf);
```
  

_Include links to JIRA tickets_
https://embl.atlassian.net/browse/ENSGENEBUI-2371

# Testing
_Have you tested it?_
Yes, on the genome mentioned in the jira ticket above

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
