### PR TITLE
Pre release conf override insufficient data

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/EnsemblAnnoHelixer_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/EnsemblAnnoHelixer_conf.pm
@@ -381,6 +381,7 @@ sub pipeline_wide_parameters {
     wide_ensembl_release => $self->o('ensembl_release'),
     load_toplevel_only => $self->o('load_toplevel_only'),
     skip_braker => 1, # default skip otherfeatures braker
+    override_evidence_threshold => 0, # default do not override evidence threshold
   };
 }
 
@@ -574,7 +575,8 @@ sub pipeline_analyses {
       -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
       -parameters => {
         cmd => 'MAIN_LINES=$(wc -l < "#rnaseq_summary_file#"); GENUS_LINES=$(wc -l < "#rnaseq_summary_file_genus#"); ' .
-              'if [ $MAIN_LINES -ge ' . $self->o('rnaseq_main_file_min_lines') . ' ] || ' .
+              'if [ "#override_evidence_threshold#" -eq 1 ]; then exit 0; ' .
+              'elif [ $MAIN_LINES -ge ' . $self->o('rnaseq_main_file_min_lines') . ' ] || ' .
               '( [ $MAIN_LINES -lt ' . $self->o('rnaseq_main_file_min_lines') . ' ] && [ $GENUS_LINES -ge ' . $self->o('rnaseq_genus_file_min_lines') . ' ] ) || ' .
               '[ -s "#long_read_summary_file#" ] || ' .
               '[ -n "#helixer_lineage#" ]; then exit 0; ' .
@@ -758,8 +760,8 @@ sub pipeline_analyses {
       -logic_name => 'check_load_meta_info',
       -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
       -parameters => {
-        cmd => 'MAIN_LINES=$(wc -l < "#rnaseq_summary_file#"); GENUS_LINES=$(wc -l < "#rnaseq_summary_file_genus#"); ' .
-              'if [ $MAIN_LINES -ge ' . $self->o('rnaseq_main_file_min_lines') . ' ] || ' .
+        cmd => 'if [ "#override_evidence_threshold#" -eq 1 ]; then exit 1; ' .
+              'elif [ $MAIN_LINES -ge ' . $self->o('rnaseq_main_file_min_lines') . ' ] || ' .
               '( [ $MAIN_LINES -lt ' . $self->o('rnaseq_main_file_min_lines') . ' ] && [ $GENUS_LINES -ge ' . $self->o('rnaseq_genus_file_min_lines') . ' ] ) || ' .
               '[ -s "#long_read_summary_file#" ]; then exit 1; ' .
               'else exit 2; fi',
@@ -902,11 +904,11 @@ sub pipeline_analyses {
       -logic_name => 'check_transcriptomic_data',
       -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
       -parameters => {
-        cmd => 'MAIN_LINES=$(wc -l < "#rnaseq_summary_file#"); GENUS_LINES=$(wc -l < "#rnaseq_summary_file_genus#"); ' .
-              'if [ $MAIN_LINES -ge ' . $self->o('rnaseq_main_file_min_lines') . ' ] || ' .
-              '( [ $MAIN_LINES -lt ' . $self->o('rnaseq_main_file_min_lines') . ' ] && [ $GENUS_LINES -ge ' . $self->o('rnaseq_genus_file_min_lines') . ' ] ) || ' .
-              '[ -s "#long_read_summary_file#" ]; then exit 1; ' .
-              'else exit 2; fi',
+          cmd => 'if [ "#override_evidence_threshold#" -eq 1 ]; then exit 1; ' .
+                'elif [ $MAIN_LINES -ge ' . $self->o('rnaseq_main_file_min_lines') . ' ] || ' .
+                '( [ $MAIN_LINES -lt ' . $self->o('rnaseq_main_file_min_lines') . ' ] && [ $GENUS_LINES -ge ' . $self->o('rnaseq_genus_file_min_lines') . ' ] ) || ' .
+                '[ -s "#long_read_summary_file#" ]; then exit 1; ' .
+                'else exit 2; fi', 
         return_codes_2_branches => { 
           '1' => 1,  # Sufficient transcriptomic data - use RNA-seq annotation
           '2' => 2,  # Insufficient transcriptomic data - use softmasking annotation

--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/EnsemblAnnoHelixer_conf.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/EnsemblAnnoHelixer_conf.pm
@@ -42,7 +42,7 @@ sub default_options {
     'num_threads'                  => 20,
     'gpu'                          => 'gpu:a100:2',
     'dbowner'                      => '' || $ENV{EHIVE_USER} || $ENV{USER},
-    'base_output_dir'              => '',
+    'base_output_dir'              => '/hps/nobackup/flicek/ensembl/genebuild/jackt/test',
     'init_config'                  => '', #path for configuration file (custom loading)
     'override_clade'               => '', #optional, already defined in ProcessGCA
     'protein_file'                 => '', #optional, already defined in ProcessGCA
@@ -58,7 +58,7 @@ sub default_options {
     'pipeline_name'                => '' || $self->o('production_name') . $self->o('production_name_modifier'),
     'user_r'                       => 'ensro',                                                                                                                # read only db user
     'user'                         => 'ensadmin',                                                                                                                # write db user
-    'password'                     => '',                                                                                                                # password for write db user
+    'password'                     => 'ensembl',                                                                                                                # password for write db user
     'server_set'                   => '',                                                                                                                # What server set to user, e.g. set1
     'busco_input_file_stid'        => 'stable_id_to_dump.txt',
     'species_name'                 => '', #optional, already defined in ProcessGCA e.g. mus_musculus
@@ -76,7 +76,7 @@ sub default_options {
     'stable_id_start'              => '', #optional, already defined in ProcessGCA When mapping is not required this is usually set to 0
     'mapping_required'             => '0',# If set to 1 this will run stable_id mapping sometime in the future. At the moment it does nothing
     'uniprot_version'              => 'uniprot_2021_04',                                                                                                 # What UniProt data dir to use for various analyses
-    'production_name_modifier'     => '',                                                                                                                # Do not set unless working with non-reference strains, breeds etc. Must include _ in modifier, e.g. _hni for medaka strain HNI
+    'production_name_modifier'     => 'test',                                                                                                                # Do not set unless working with non-reference strains, breeds etc. Must include _ in modifier, e.g. _hni for medaka strain HNI
 
     # Keys for custom loading, only set/modify if that's what you're doing
     'load_toplevel_only'        => '1',                                                                                                                  # This will not load the assembly info and will instead take any chromosomes, unplaced and unlocalised scaffolds directly in the DNA table
@@ -503,10 +503,12 @@ sub pipeline_analyses {
       -logic_name => 'check_rnaseq_files',
       -module     => 'Bio::EnsEMBL::Hive::RunnableDB::SystemCmd',
       -parameters => {
-        cmd => 'MAIN_LINES=$(wc -l < "#rnaseq_summary_file#"); GENUS_LINES=$(wc -l < "#rnaseq_summary_file_genus#"); ' .
-              'if [ $MAIN_LINES -ge ' . $self->o('rnaseq_main_file_min_lines') . ' ]; then exit 1; ' .
-              'elif [ $MAIN_LINES -lt ' . $self->o('rnaseq_main_file_min_lines') . ' ] && [ $GENUS_LINES -ge ' . $self->o('rnaseq_genus_file_min_lines') . ' ]; then exit 2; ' .
-              'else exit 3; fi',
+          cmd => 'MAIN_LINES=$(wc -l < "#rnaseq_summary_file#"); GENUS_LINES=$(wc -l < "#rnaseq_summary_file_genus#"); ' .
+                'if [ "#override_evidence_threshold#" -eq 1 ]; then ' .
+                '  if [ $MAIN_LINES -ge 1 ]; then exit 1; else exit 2; fi; ' .
+                'elif [ $MAIN_LINES -ge ' . $self->o('rnaseq_main_file_min_lines') . ' ]; then exit 1; ' .
+                'elif [ $MAIN_LINES -lt ' . $self->o('rnaseq_main_file_min_lines') . ' ] && [ $GENUS_LINES -ge ' . $self->o('rnaseq_genus_file_min_lines') . ' ]; then exit 2; ' .
+                'else exit 3; fi',
         return_codes_2_branches => { 
           '1' => 1,  # Use main file (species-level)
           '2' => 2,  # Use genus file


### PR DESCRIPTION
In this PR we introduce a pipeline wide parameter that allows the genebuilder to override the evidence quantity thresholds that we previously introduced. 

This parameter is by default set to 0 but when changed to 1, each genome gets an automatic pass on evidence level checks. 

