### PR TITLE
Edited the split command for parsing GFF

### DIFF
--- a/scripts/refseq/parse_ncbi_gff3.pl
+++ b/scripts/refseq/parse_ncbi_gff3.pl
@@ -823,21 +823,48 @@ sub process_cds {
       $transl_except =~ s/%2C/,/g;
 
       my @entries;
-      if ($transl_except =~ /\(pos:complement\(join\(/) {
-        # Complex case - extract simple ranges only
-        while ($transl_except =~ /(\d+)\.\.(\d+)[^,)]*aa:(\w+)/g) {
-          push @entries, "$1..$2,aa:$3";
-        }
+      if ($transl_except =~ /join\(/) {
+        # Skip join constructs - downstream cannot handle split codons
+        print STDERR "DEBUG: Skipping join() construct for transcript: " . $transcript->display_id . "\n";
+        print STDERR "DEBUG: transl_except value: '$transl_except'\n";
+        next;
       } else {
-        # Simple case
-        @entries = split(',', $transl_except);
+        # Split on ),( to separate complete entries
+        $transl_except =~ s/^\(|\)$//g;  # Remove outer parentheses
+        my @raw_entries = split /\),\(/, $transl_except;
+        @entries = map { "($_)" } @raw_entries;  # Add parentheses back
+        #print STDERR "DEBUG: Found " . scalar(@entries) . " transl_except entries for " . $transcript->display_id . "\n";
       }
 
       foreach my $attribute_string (@entries) {
-        my ($attribute_start, $attribute_end, $type) = $attribute_string =~ /(\d+)\.\.(\d+)\)?[^:]+:(\w+)/;
+        my ($attribute_start, $attribute_end, $type);
 
-        # Validation
-        next unless defined $attribute_start && defined $attribute_end && defined $type;
+        #print STDERR "DEBUG: Processing entry: '$attribute_string'\n";
+
+        if ($attribute_string =~ /\(pos:(\d+)\.\.(\d+),aa:(\w+)\)/) {
+          # Simple range: (pos:123..456,aa:Other)
+          ($attribute_start, $attribute_end, $type) = ($1, $2, $3);
+          #print STDERR "DEBUG: Parsed simple range: $attribute_start..$attribute_end, type=$type\n";
+        }
+        elsif ($attribute_string =~ /\(pos:complement\((\d+)\.\.(\d+)\),aa:(\w+)\)/) {
+          # Complement range: (pos:complement(123..456),aa:Other)
+          ($attribute_start, $attribute_end, $type) = ($1, $2, $3);
+          #print STDERR "DEBUG: Parsed complement range: $attribute_start..$attribute_end, type=$type\n";
+        }
+        elsif ($attribute_string =~ /\(pos:(\d+),aa:(\w+)\)/) {
+          # Single position: (pos:123,aa:TERM)
+          ($attribute_start, $attribute_end, $type) = ($1, $1, $2);
+          #print STDERR "DEBUG: Parsed single position: $attribute_start, type=$type\n";
+        }
+        else {
+          print STDERR "DEBUG: Failed to parse entry: '$attribute_string'\n";
+        }
+
+        # Enhanced validation
+        unless (defined $attribute_start && defined $attribute_end && defined $type) {
+          print STDERR "DEBUG: Skipping malformed entry for transcript " . $transcript->display_id . ": '$attribute_string'\n";
+          next;
+        }
 
         my $attribute;
         if ($type eq 'Sec') {


### PR DESCRIPTION
Complex structures in the attributes of refseq GFF (shown in example), caused range to be miss-assigned thus failing due to the end coordinate being smalled than the starting one.

After some looking around, turns out the split that originally handles the attribute was not design to manage complex, nested, attributes. In changing that, but keeping a condition for the normal non-nested cases, all instances in my test were handled as expected.

Simple case:
`[[rest of the line]]transl_except=(pos:16975745..16975747%2Caa:Other)`

Nested case:
`[[rest of the line]]transl_except=(pos:complement(join(11655574%2C11
655751..11655752))%2Caa:Other),(pos:complement(11655454..11655456)%2Caa:Other)`

# Requirements
When creating your Pull request, please fill out the template below:

# PR details
Fix for a very specific (and probably not very wide-spreaded edge case.

_Include a short description_
(See above for details). Amend of a split function that was not covering all possible cases.

_Include links to JIRA tickets_
No Jira ticket.

# Testing
_Have you tested it?_
Tested it in a small subset of the problematic GFF (the scaffold containing the entity that originally flagged the issue.

# Assign to the weekly GitHub reviewer
@JackCurragh