### PR TITLE
Add limitBAMsortRAM as optional parameter to STAR

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/Config/StarScallopRnaseq.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/Config/StarScallopRnaseq.pm
@@ -206,6 +206,8 @@ sub default_options {
     star_threads    => 12,
     scallop_threads => 2,
     rnaseq_merge_threads => 12,
+
+    star_bam_sort_ram => 0,
     # Please assign some or all columns from the summary file to the
     # some or all of the following categories.  Multiple values can be
     # separted with commas. ID, SM, DS, CN, is_paired, filename, read_length, is_13plus,
@@ -514,6 +516,7 @@ sub pipeline_analyses {
         short_read_aligner => $self->o('star_path'),
         genome_dir         => catfile( $self->o('output_path'), 'genome_dumps' ),
         num_threads        => $self->o('star_threads'),
+        limitBAMsortRAM    => $self->o('star_bam_sort_ram'),
       },
       -flow_into => {
         2 => ['scallop'],
@@ -532,6 +535,7 @@ sub pipeline_analyses {
         short_read_aligner => $self->o('star_path'),
         genome_dir         => catfile( $self->o('output_path'), 'genome_dumps' ),
         num_threads        => $self->o('star_threads'),
+        limitBAMsortRAM    => $self->o('star_bam_sort_ram'),
       },
       -flow_into => {
         2 => ['scallop'],

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveStar.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveStar.pm
@@ -73,6 +73,7 @@ sub param_defaults {
     threads => 1,
     samtools => 'samtools',
     samtools_use_threading => 1,
+    limitBAMsortRAM => 0,
 	skip_analysis => 0,
   }
 }
@@ -131,7 +132,7 @@ sub fetch_input {
      -fastq          => $filepath1,
      -fastqpair      => $filepath2,
      -threads        => $self->param('num_threads'),
-	 #-mem_request	 => $self->param('limitBAM'),
+	   -limitBAMsortRAM	 => $self->param('limitBAMsortRAM'),
     );
     if ($self->param_is_defined('rg_lines')) {
       $runnable->rg_lines($self->param('rg_lines'));

--- a/modules/Bio/EnsEMBL/Analysis/Runnable/Star.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Runnable/Star.pm
@@ -78,12 +78,13 @@ sub new {
   my ( $class, @args ) = @_;
 
   my $self = $class->SUPER::new(@args);
-  my ($decompress, $sample_id, $genome_dir, $threads) = rearrange([qw (DECOMPRESS SAMPLE_NAME GENOME_DIR THREADS)],@args);
+  my ($decompress, $sample_id, $genome_dir, $threads, $limitbamsortram) = rearrange([qw (DECOMPRESS SAMPLE_NAME GENOME_DIR THREADS LIMITBAMSORTRAM)],@args);
   $self->throw("Genome file must be indexed, '$genome_dir/SA' does not exist\n") unless (-e $genome_dir.'/SA');
   $self->genome($genome_dir);
   $self->sample_id($sample_id);
   $self->threads($threads);
   $self->is_file_compressed($decompress);
+  $self->limitBAMsortRAM($limitbamsortram) if $limitbamsortram;
   return $self;
 }
 
@@ -114,6 +115,7 @@ sub run {
   }
   $options .= ' --outSAMattrRGline "'.$self->rg_lines.'"' if ($self->rg_lines);
   $options .= ' --outSAMattributes "'.$self->sam_attributes.'"' if ($self->sam_attributes);
+  $options .= ' --limitBAMsortRAM '.$self->limitBAMsortRAM if ($self->limitBAMsortRAM);
 
   # run STAR
   my $command = $self->program." --limitSjdbInsertNsj 2000000 --outFilterIntronMotifs RemoveNoncanonicalUnannotated --outSAMstrandField intronMotif --runThreadN ".$self->threads." --twopassMode Basic --runMode alignReads --genomeDir ".$self->genome." --readFilesIn $fastq $fastqpair --outFileNamePrefix $out_dir $options --outTmpDir $tmp_dir --outSAMtype BAM SortedByCoordinate";
@@ -230,6 +232,24 @@ sub threads {
     $self->{'_threads'} = $value;
   }
   return $self->{'_threads'};
+}
+
+
+=head2 limitBAMsortRAM
+
+ Arg [1]    : (optional) int
+ Description: Getter/setter for the maximum RAM available for BAM sorting in bytes
+ Returntype : Int
+ Exceptions : None
+
+=cut
+
+sub limitBAMsortRAM {
+  my ($self, $value) = @_;
+  if (defined $value) {
+    $self->{'_limitBAMsortRAM'} = $value;
+  }
+  return $self->{'_limitBAMsortRAM'};
 }
 
 


### PR DESCRIPTION
STAR was failing during BAM sorting on large fastq because --limitBAMsortRAM was never passed, defaulting to ~2GB internally.

Added the parameter option as required by the different agents of this operation (Star.pm, HiveStar.pm, and StarScallopRnaseq.pm). Parameter was called star_bam_sort_ram and has been defaulted to 0.

# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_

Fix and update.

_Include a short description_

STAR was failing during BAM sorting on large datasets because `--limitBAMsortRAM` was never passed, defaulting to ~2GB internally. Added `limitBAMsortRAM` as an optional parameter through `Runnable::Star`, `HiveStar.pm` and `StarScallopRnaseq.pm`. Exposed in the config as `star_bam_sort_ram` (which default to 0),

_Include links to JIRA tickets_

https://embl.atlassian.net/browse/ENSGENEBUI-3609

# Testing
_Have you tested it?_

I've tested it by manually adding the option to an ongoing pipeline. I've tested the config by recreating an already completed rnaseq_pipe. 

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_

Weekly rota: @vianeyBE 