### PR TITLE
Fix HiveSelenocysteineFinder::get_best_transcript

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveSelenocysteineFinder.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveSelenocysteineFinder.pm
@@ -292,7 +292,7 @@ sub get_best_transcript {
 	  my @sfs;
 	  foreach my $exon (@{$genewise_transcript->get_all_Exons}) {
   		foreach my $sf (@{$exon->get_all_supporting_features}) {
-    	  push(@sfs, $sf->ungapped_features);
+    	  push(@sfs, $sf->ungapped_features); # splits each feature into pieces that satisfy the 3:1 ratio
   		}
 	  }
       my $new_tsf = Bio::EnsEMBL::DnaPepAlignFeature->new(-features => \@sfs, -align_type => 'ensembl');

--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveSelenocysteineFinder.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveSelenocysteineFinder.pm
@@ -289,10 +289,12 @@ sub get_best_transcript {
 # We might need to chage it but there are some warning in the GeneWise module...
 # So let's change it to a DnaPepAlignFeature
       $genewise_transcript->flush_supporting_features;
-      my @sfs;
-      foreach my $exon (@{$genewise_transcript->get_all_Exons}) {
-        push(@sfs, @{$exon->get_all_supporting_features});
-      }
+	  my @sfs;
+	  foreach my $exon (@{$genewise_transcript->get_all_Exons}) {
+  		foreach my $sf (@{$exon->get_all_supporting_features}) {
+    	  push(@sfs, $sf->ungapped_features);
+  		}
+	  }
       my $new_tsf = Bio::EnsEMBL::DnaPepAlignFeature->new(-features => \@sfs, -align_type => 'ensembl');
       $genewise_transcript->add_supporting_features($new_tsf);
       $self->warning("GOOD MATCH!! The GeneWise protein match the original protein $accession");


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_

Fix

_Include a short description_

Feature lengths not comparable" for multi-exon GeneWise alignments with internal gaps.

HiveSelenocysteineFinder was failing with:
```
MSG: Feature lengths not comparable Lengths:234 79 Ratios:3 1
STACK Bio::EnsEMBL::BaseAlignFeature::_parse_ensembl_features BaseAlignFeature.pm:825
STACK ... HiveSelenocysteineFinder::get_best_transcript HiveSelenocysteineFinder.pm:296
```

Reproduced consistently across 4 separate annotation pipelines for the same query, A9CTP4.2 (a 153 aa selenoprotein with two U residues, source_db=seleno).

TL;DR: Exons get pushed into a flat list and aligned. Before this alignment they are parsed and check for consistency. If the residue of interes falls within specific positions (start or end) they are not counted (gap) thus producing a diference in expected length, even with an underlying valid alignment.

By decomposing each exon on the ungapped, divisible by 3 blocks that form them, we keep the same information, alignments, and now consistency won;t complain.

For exons without this issue, the returned object should be the same and all module should work as originally.

_Include links to JIRA tickets_

None

# Testing
_Have you tested it?_

Tested it:
- For the ofending selenoprotein (A9CTP4.2) -> Completed succesfully.
- For other selenoproteins that had been successfull before this patch:
  - A0A060IG47.1
  - A0A0H3Y7L0.1
- With runWorker.pl and within the pipeline -> All good.

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_

@vianeyBE