### PR TITLE
Hotfix/load mt ncbi download

### DIFF
--- a/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveAssemblyLoading/HiveLoadMitochondrion.pm
+++ b/modules/Bio/EnsEMBL/Analysis/Hive/RunnableDB/HiveAssemblyLoading/HiveLoadMitochondrion.pm
@@ -81,14 +81,22 @@ sub fetch_input {
     my $scientific_name = $target_db->get_MetaContainerAdaptor->get_scientific_name;
     my $taxon_id = $target_db->get_MetaContainerAdaptor->get_taxonomy_id;
     my $email = $ENV{HIVE_EMAIL} || 'genebuild@ebi.ac.uk';
+
+    # NCBI API key: raises rate limit from 3 req/sec to 10 req/sec.
+    # Set via NCBI_API_KEY env var (same convention as HiveDownloadNCBImRNA).
+    my %api_key_param;
+    $api_key_param{-api_key} = $ENV{NCBI_API_KEY} if $ENV{NCBI_API_KEY};
+
     my $factory = Bio::DB::EUtilities->new(
       -eutil => 'esearch',
       -db     => 'nuccore',
       -term   => '"'.$scientific_name.'"[Organism] AND biomol_genomic[PROP] AND refseq[filter] AND mitochondrion[filter]',
       -email  => $email,
       -retmax => 5,
+      %api_key_param,
     );
-    if ($factory->get_count) {
+
+    if ($self->_eutils_with_backoff(sub { $factory->get_count })) {
       $self->say_with_header(join(' ID: ', $factory->get_ids));
       my @uids = $factory->get_ids;
 
@@ -96,11 +104,12 @@ sub fetch_input {
         -eutil => 'esummary',
         -db    => 'nuccore',
         -email  => $email,
-        -id    => \@uids
+        -id    => \@uids,
+        %api_key_param,
       );
 
       my %mt_accessions;
-      while (my $ds = $factory->next_DocSum) {
+      while (my $ds = $self->_eutils_with_backoff(sub { $factory->next_DocSum })) {
         $self->say_with_header('ID: '.$ds->get_id.' ACCESSION: '.join(' ', $ds->get_contents_by_name('AccessionVersion')));
         my ($mt_accession) = $ds->get_contents_by_name('AccessionVersion');
         my ($tax_id) = $ds->get_contents_by_name('TaxId');
@@ -134,6 +143,45 @@ sub fetch_input {
   }
   else {
     $self->complete_early('No mitochondria for this species');
+  }
+}
+
+=head2 _eutils_with_backoff
+
+ Arg [1]    : Coderef wrapping a single Bio::DB::EUtilities call
+              (e.g. sub { $factory->get_count }, sub { $factory->next_DocSum })
+ Arg [2]    : Int max retry attempts (default 5)
+ Description: Calls the given coderef. If it dies with a "Too Many Requests"
+              Bio::Root::Exception (NCBI rate limiting), retries with
+              exponential backoff (1s, 2s, 4s, 8s, 16s). Any other exception
+              is rethrown immediately. After exhausting retries, the last
+              exception is rethrown.
+ Returntype : Whatever the coderef returns
+ Exceptions : Rethrows non-rate-limit exceptions, or the rate-limit exception
+              after max attempts are exhausted.
+
+=cut
+
+sub _eutils_with_backoff {
+  my ($self, $code, $max_attempts) = @_;
+  $max_attempts ||= 5;
+
+  my $attempt = 0;
+  my $delay = 1;
+  while (1) {
+    my $result = eval { $code->() };
+    if (!$@) {
+      return $result;
+    }
+    if ($@ =~ /Too Many Requests/ and $attempt < $max_attempts) {
+      $attempt++;
+      $self->say_with_header("NCBI rate limit hit, retrying in ${delay}s (attempt $attempt/$max_attempts)");
+      sleep($delay);
+      $delay *= 2;
+    }
+    else {
+      die $@;
+    }
   }
 }
 

--- a/scripts/refseq/load_mitochondria.pl
+++ b/scripts/refseq/load_mitochondria.pl
@@ -194,11 +194,23 @@ if ($help) {
     exec('perldoc', $0);
 }
 
-my $ftp_cmd = 'wget -q "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&retmod=text&rettype=%s&id=%s"';
+my $ftp_cmd = 'wget -q "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&retmode=text&rettype=%s&id=%s"';
 if (exists $opt{download}) {
-  if (system(sprintf($ftp_cmd, 'gb', $MIT_DB_VERSION).' -O '.$MIT_GENBANK_FILE)) {
-    throw("Could not retrieve the genbank file");
+  my $max_attempts = 5;
+  my $attempt = 0;
+  my $delay = 1;
+  my $download_ok = 0;
+  while ($attempt < $max_attempts) {
+    if (!system(sprintf($ftp_cmd, 'gb', $MIT_DB_VERSION).' -O '.$MIT_GENBANK_FILE)) {
+      $download_ok = 1;
+      last;
+    }
+    $attempt++;
+    warning("Genbank download attempt $attempt failed, retrying in ${delay}s...");
+    sleep($delay);
+    $delay *= 2;
   }
+  throw("Could not retrieve the genbank file after $max_attempts attempts") unless $download_ok;
 }
 
 ############################

--- a/scripts/refseq/load_mitochondria.pl
+++ b/scripts/refseq/load_mitochondria.pl
@@ -262,7 +262,14 @@ if (!$slice) {
       else {
         my ($rev, $accession, $start, $end) = $fragment =~ /(complement\()?([^:]+):(\d+)\.\.(\d+)/;
         my $length = $end-$start+1;
-        open(my $fasta_file, sprintf($ftp_cmd, 'fasta', $accession).' -O - |') or throw("Could not fetch fasta for $accession");
+		# NOTE: This efetch call has no rate-limit handling, unlike the GenBank
+		# download above and the esearch/esummary calls in fetch_input (which were
+		# patched after hitting "Too Many Requests" failures in production). This
+		# call hasn't actually been observed to fail the same way, but it's the same
+		# kind of unauthenticated NCBI request, so it seems worth a look if it ever
+		# starts failing intermittently.
+		# If you are having this isse, replicate the behauviour of the previous blocvk here too.
+		open(my $fasta_file, sprintf($ftp_cmd, 'fasta', $accession).' -O - |') or throw("Could not fetch fasta for $accession");
         my $fasta_parser = Bio::EnsEMBL::IO::Parser::Fasta->open($fasta_file);
         $fasta_parser->next;
         my $tmp_sequence = substr($fasta_parser->getSequence, $start-1, $length);
@@ -299,7 +306,16 @@ foreach my $chromosome (@{$slice->adaptor->fetch_all_karyotype}) {
 if ($max_attrib) {
   my ($attrib) = @{$slice->get_all_Attributes('karyotype_rank')};
   if ($attrib and $attrib->value != $max_attrib) {
-    $attrib_adaptor->remove_on_Slice($slice, $attrib);
+		# NOTE: Can't find remove_on_Slice in repos or logs or "blame"
+		# (checked via grep across the full checked-out modenv) and throws "Can't
+		# locate object method" if this branch is reached, i.e. if MT already has a
+		# stale karyotype_rank attribute from a previous run. remove_from_Slice
+		# exists and is the closest match, but takes an attribute code rather than
+		# an object, and its exact delete semantics weren't checked closely enough
+		# to be confident it's a safe drop-in replacement. In case you have found an
+		# issue with this, the sugestion was to change line for:
+		# $attrib_adaptor->remove_from_Slice($slice, $attrib->code);
+		$attrib_adaptor->remove_on_Slice($slice, $attrib);
   }
   unless ($attrib and $attrib->value != $max_attrib) {
     $attrib = Bio::EnsEMBL::Attribute->new(


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_

fix/new feature

_Include a short description_

HiveLoadMitochondrion and the downstream load_mitochondria.pl script make multiple unauthenticated NCBI EUtilities/efetch calls (esearch, esummary, GenBank download via wget) with no retry logic. NCBI's rate limiting (3 req/sec for unauthenticated requests) causes intermittent "Too Many Requests failures", requiring multiple manual job retries to succeed. Observed in production when loading the MT genome for GCA_054883215.1 (Axis porcinus) by @swatiebi  originally. Replicated by me (job failed 6 times across the esearch/esummary accession lookup before eventually succeeding on retry).

Added optional NCBI API key support to HiveLoadMitochondrion.pm via the NCBI_API_KEY environment variable, passed to both the esearch and esummary Bio::DB::EUtilities calls (raises the rate limit from 3 req/sec to 10 req/sec when set). Also added a new _eutils_with_backoff helper that wraps individual EUtilities calls (get_count, next_DocSum) in exponential backoff (1s/2s/4s/8s/16s, 5 attempts) on Too Many Requests exceptions specifically, while rethrowing any other exception immediately.

Fixed a typo in the efetch URL (retmod → retmode) and switched http → https to avoid the HSTS redirect hop for load_mitochondria.pl. Also wrapped the GenBank file download (wget via system()) in the same exponential backoff pattern, retrying on non-zero exit rather than failing immediately.

Also added notes for a couple of potential issues that I have left unmodified for lack of evidence of failure.

_Include links to JIRA tickets_

https://embl.atlassian.net/browse/ENSGENEBUI-3841

# Testing
_Have you tested it?_

Tested on same data Swati originally used (although due to the nature of the fail, data is less important that NCBI activity).

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_

@swatiebi (for originally working on this)
