### PR TITLE
Skip NCBIOrtholog xrefs in parse_ncbi_gff3.pl

### DIFF
--- a/scripts/refseq/parse_ncbi_gff3.pl
+++ b/scripts/refseq/parse_ncbi_gff3.pl
@@ -69,6 +69,7 @@ my %nondisplaydb = (
 my %unknowndbs = (
   HPRD => 1,
   Ensembl => 1,
+  NCBIOrtholog => 1,
 );
 &GetOptions (
             'h|host|dbhost=s'   => \$host,


### PR DESCRIPTION
Dbxref=NCBIOrtholog:... entries in NCBI RefSeq GFF3 files have no corresponding external_db row in Ensembl core schemas, causing GeneAdaptor::store to fail via DBEntryAdaptor::_check_external_db ("external_db [NCBIOrtholog] release [] does not exist").

Add NCBIOrtholog to %unknowndbs alongside the existing HPRD/Ensembl entries so add_xrefs() skips it, consistent with how those other unmapped Dbxref types are already handled.

# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_

Fix

_Include a short description_

`parse_ncbi_gff3.pl` fails when storing genes/transcripts carrying a `Dbxref=NCBIOrtholog:...` attribute from NCBI RefSeq GFF3 files, since `NCBIOrtholog` has no corresponding `external_db` row in Ensembl core schemas. `GeneAdaptor::store` cascades to `DBEntryAdaptor::store`, which calls `_check_external_db` and throws `external_db [NCBIOrtholog] release [] does not exist`, failing the job.

This PR adds `NCBIOrtholog` to the existing `%unknowndbs` hash in `add_xrefs()`, alongside `HPRD` and `Ensembl`, so the xref is skipped rather than attached to the gene/transcript — consistent with how those other unmapped Dbxref types are already handled. No `external_db` table changes required.

_Include links to JIRA tickets_

https://embl.atlassian.net/browse/ENSGENEBUI-3937

# Testing
_Have you tested it?_

Tested on turkey refseq_import, GCF_905368555.1

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_

@JackCurragh 
